### PR TITLE
fix(validators): do not wrap regular expression in slashes if the pattern is already wrapped

### DIFF
--- a/.changeset/five-bikes-watch.md
+++ b/.changeset/five-bikes-watch.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix(validators): do not wrap regular expression in slashes if the pattern is already wrapped

--- a/packages/openapi-ts/src/compiler/types.ts
+++ b/packages/openapi-ts/src/compiler/types.ts
@@ -1006,7 +1006,13 @@ export const createRegularExpressionLiteral = ({
 }: {
   flags?: ReadonlyArray<'g' | 'i' | 'm' | 's' | 'u' | 'y'>;
   text: string;
-}) => ts.factory.createRegularExpressionLiteral(`/${text}/${flags.join('')}`);
+}) => {
+  const textWithSlashes =
+    text.startsWith('/') && text.endsWith('/') ? text : `/${text}/`;
+  return ts.factory.createRegularExpressionLiteral(
+    `${textWithSlashes}${flags.join('')}`,
+  );
+};
 
 export const createAsExpression = ({
   expression,


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/1977