### PR TITLE
fix: export default pagination keywords

### DIFF
--- a/.changeset/serious-masks-talk.md
+++ b/.changeset/serious-masks-talk.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+fix: export default pagination keywords

--- a/packages/openapi-ts/src/index.ts
+++ b/packages/openapi-ts/src/index.ts
@@ -101,6 +101,7 @@ export const defineConfig = async (config: Configs): Promise<UserConfig> =>
   typeof config === 'function' ? await config() : config;
 
 export { defaultPlugins } from './initConfigs';
+export { defaultPaginationKeywords } from './ir/pagination';
 export type { IR } from './ir/types';
 export type { OpenApi, OpenApiSchemaObject } from './openApi/types';
 export { clientDefaultConfig } from './plugins/@hey-api/client-core/config';

--- a/packages/openapi-ts/src/ir/pagination.ts
+++ b/packages/openapi-ts/src/ir/pagination.ts
@@ -1,7 +1,7 @@
 import type { Config } from '../types/config';
 import type { IR } from './types';
 
-export const DEFAULT_PAGINATION_KEYWORDS = [
+export const defaultPaginationKeywords = [
   'after',
   'before',
   'cursor',
@@ -11,10 +11,10 @@ export const DEFAULT_PAGINATION_KEYWORDS = [
 ] as const;
 
 export function getPaginationKeywordsRegExp({
-  keywords = DEFAULT_PAGINATION_KEYWORDS,
+  keywords = defaultPaginationKeywords,
 }: Config['input']['pagination'] = {}): RegExp {
   if (!keywords.length) {
-    keywords = DEFAULT_PAGINATION_KEYWORDS;
+    keywords = defaultPaginationKeywords;
   }
   const pattern = `^(${keywords.join('|')})$`;
   return new RegExp(pattern);


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/2168