### PR TITLE
fix: add `undefined` type in key map

### DIFF
--- a/packages/custom-client/src/core/params.ts
+++ b/packages/custom-client/src/core/params.ts
@@ -31,7 +31,7 @@ type KeyMap = Map<
   string,
   {
     in: Slot;
-    map?: string;
+    map?: string | undefined;
   }
 >;
 


### PR DESCRIPTION
Fixes: https://github.com/hey-api/openapi-ts/issues/2262