### PR TITLE
feat(queryKey): add optional tags parameter to query key functions

### DIFF
--- a/.changeset/flat-paws-sniff.md
+++ b/.changeset/flat-paws-sniff.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(tanstack-query): add `queryKeys.tags` and `infiniteQueryKeys.tags` options

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/@tanstack/angular-query-experimental.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/@tanstack/angular-query-experimental.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/@tanstack/angular-query-experimental.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/@tanstack/react-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/@tanstack/react-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/@tanstack/react-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/@tanstack/solid-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/@tanstack/solid-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/@tanstack/solid-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/@tanstack/svelte-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/@tanstack/svelte-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/@tanstack/svelte-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/@tanstack/vue-query.gen.ts
@@ -10,15 +10,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseURL' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseURL: options?.baseURL || (options?.client ?? _heyApiClient).getConfig().baseURL } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/@tanstack/vue-query.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/@tanstack/vue-query.gen.ts
@@ -9,15 +9,19 @@ export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'baseUrl' | 'body' | 'headers' | 'path' | 'query'> & {
         _id: string;
         _infinite?: boolean;
+        tags?: ReadonlyArray<string>;
     }
 ];
 
-const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean): [
+const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions, infinite?: boolean, tags?: ReadonlyArray<string>): [
     QueryKey<TOptions>[0]
 ] => {
     const params: QueryKey<TOptions>[0] = { _id: id, baseUrl: options?.baseUrl || (options?.client ?? _heyApiClient).getConfig().baseUrl } as QueryKey<TOptions>[0];
     if (infinite) {
         params._infinite = infinite;
+    }
+    if (tags) {
+        params.tags = tags;
     }
     if (options?.body) {
         params.body = options.body;

--- a/packages/openapi-ts/src/plugins/@tanstack/angular-query-experimental/config.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/angular-query-experimental/config.ts
@@ -20,6 +20,7 @@ export const defaultConfig: TanStackAngularQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}InfiniteQueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),
@@ -62,6 +63,7 @@ export const defaultConfig: TanStackAngularQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}QueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),

--- a/packages/openapi-ts/src/plugins/@tanstack/angular-query-experimental/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/angular-query-experimental/types.d.ts
@@ -56,6 +56,13 @@ export type UserConfig = Plugin.Name<'@tanstack/angular-query-experimental'> & {
          * @see https://tanstack.com/query/v5/docs/framework/angular/reference/infiniteQueryOptions
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in infinite query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated infinite query options helpers.
@@ -173,6 +180,13 @@ export type UserConfig = Plugin.Name<'@tanstack/angular-query-experimental'> & {
          * @see https://tanstack.com/query/v5/docs/framework/angular/reference/queryKey
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated query options helpers.
@@ -258,6 +272,13 @@ export type Config = Plugin.Name<'@tanstack/angular-query-experimental'> & {
      * @see https://tanstack.com/query/v5/docs/framework/angular/reference/infiniteQueryOptions
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in infinite query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated infinite query options helpers.
@@ -345,6 +366,13 @@ export type Config = Plugin.Name<'@tanstack/angular-query-experimental'> & {
      * @see https://tanstack.com/query/v5/docs/framework/angular/reference/queryKey
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated query options helpers.

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/queryKey.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/queryKey.ts
@@ -272,7 +272,7 @@ const createQueryKeyLiteral = ({
     parameters: [
       tsc.ots.string(id),
       'options',
-      tsc.ots.boolean(!!isInfinite),
+      isInfinite || tagsExpression ? tsc.ots.boolean(Boolean(isInfinite)) : undefined,
       tagsExpression ? tagsExpression : undefined,
     ],
   });

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/queryKey.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/queryKey.ts
@@ -272,7 +272,9 @@ const createQueryKeyLiteral = ({
     parameters: [
       tsc.ots.string(id),
       'options',
-      isInfinite || tagsExpression ? tsc.ots.boolean(Boolean(isInfinite)) : undefined,
+      isInfinite || tagsExpression
+        ? tsc.ots.boolean(Boolean(isInfinite))
+        : undefined,
       tagsExpression ? tagsExpression : undefined,
     ],
   });

--- a/packages/openapi-ts/src/plugins/@tanstack/react-query/config.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/react-query/config.ts
@@ -20,6 +20,7 @@ export const defaultConfig: TanStackReactQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}InfiniteQueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),
@@ -62,6 +63,7 @@ export const defaultConfig: TanStackReactQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}QueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),

--- a/packages/openapi-ts/src/plugins/@tanstack/react-query/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/react-query/types.d.ts
@@ -61,6 +61,13 @@ export type UserConfig = Plugin.Name<'@tanstack/react-query'> & {
          * @see https://tanstack.com/query/v5/docs/framework/react/reference/infiniteQueryOptions
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in infinite query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated infinite query options helpers.
@@ -178,6 +185,13 @@ export type UserConfig = Plugin.Name<'@tanstack/react-query'> & {
          * @see https://tanstack.com/query/v5/docs/framework/react/reference/queryKey
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated query options helpers.
@@ -262,6 +276,13 @@ export type Config = Plugin.Name<'@tanstack/react-query'> & {
      * @see https://tanstack.com/query/v5/docs/framework/react/reference/infiniteQueryOptions
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in infinite query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated infinite query options helpers.
@@ -346,6 +367,13 @@ export type Config = Plugin.Name<'@tanstack/react-query'> & {
      * @see https://tanstack.com/query/v5/docs/framework/react/reference/queryKey
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated query options helpers.

--- a/packages/openapi-ts/src/plugins/@tanstack/solid-query/config.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/solid-query/config.ts
@@ -20,6 +20,7 @@ export const defaultConfig: TanStackSolidQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}InfiniteQueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),
@@ -62,6 +63,7 @@ export const defaultConfig: TanStackSolidQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}QueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),

--- a/packages/openapi-ts/src/plugins/@tanstack/solid-query/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/solid-query/types.d.ts
@@ -56,6 +56,13 @@ export type UserConfig = Plugin.Name<'@tanstack/solid-query'> & {
          * @see https://tanstack.com/query/v5/docs/framework/solid/reference/createInfiniteQuery
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in infinite query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated infinite query options helpers.
@@ -173,6 +180,13 @@ export type UserConfig = Plugin.Name<'@tanstack/solid-query'> & {
          * @see https://tanstack.com/query/v5/docs/framework/solid/reference/queryKey
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated query options helpers.
@@ -258,6 +272,13 @@ export type Config = Plugin.Name<'@tanstack/solid-query'> & {
      * @see https://tanstack.com/query/v5/docs/framework/solid/reference/createInfiniteQuery
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in infinite query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated infinite query options helpers.
@@ -345,6 +366,13 @@ export type Config = Plugin.Name<'@tanstack/solid-query'> & {
      * @see https://tanstack.com/query/v5/docs/framework/solid/reference/queryKey
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated query options helpers.

--- a/packages/openapi-ts/src/plugins/@tanstack/svelte-query/config.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/svelte-query/config.ts
@@ -20,6 +20,7 @@ export const defaultConfig: TanStackSvelteQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}InfiniteQueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),
@@ -62,6 +63,7 @@ export const defaultConfig: TanStackSvelteQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}QueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),

--- a/packages/openapi-ts/src/plugins/@tanstack/svelte-query/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/svelte-query/types.d.ts
@@ -56,6 +56,13 @@ export type UserConfig = Plugin.Name<'@tanstack/svelte-query'> & {
          * @see https://tanstack.com/query/v5/docs/framework/svelte/reference/createInfiniteQuery
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in infinite query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated infinite query options helpers.
@@ -173,6 +180,13 @@ export type UserConfig = Plugin.Name<'@tanstack/svelte-query'> & {
          * @see https://tanstack.com/query/v5/docs/framework/svelte/reference/queryKey
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated query options helpers.
@@ -258,6 +272,13 @@ export type Config = Plugin.Name<'@tanstack/svelte-query'> & {
      * @see https://tanstack.com/query/v5/docs/framework/svelte/reference/createInfiniteQuery
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in infinite query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated infinite query options helpers.
@@ -345,6 +366,13 @@ export type Config = Plugin.Name<'@tanstack/svelte-query'> & {
      * @see https://tanstack.com/query/v5/docs/framework/svelte/reference/queryKey
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated query options helpers.

--- a/packages/openapi-ts/src/plugins/@tanstack/vue-query/config.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/vue-query/config.ts
@@ -20,6 +20,7 @@ export const defaultConfig: TanStackVueQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}InfiniteQueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),
@@ -62,6 +63,7 @@ export const defaultConfig: TanStackVueQueryPlugin['Config'] = {
         case: plugin.config.case ?? 'camelCase',
         enabled: true,
         name: '{{name}}QueryKey',
+        tags: false,
       },
       mappers: {
         boolean: (enabled) => ({ enabled }),

--- a/packages/openapi-ts/src/plugins/@tanstack/vue-query/types.d.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/vue-query/types.d.ts
@@ -56,6 +56,13 @@ export type UserConfig = Plugin.Name<'@tanstack/vue-query'> & {
          * @see https://tanstack.com/query/v5/docs/framework/vue/reference/infiniteQueryOptions
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in infinite query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated infinite query options helpers.
@@ -173,6 +180,13 @@ export type UserConfig = Plugin.Name<'@tanstack/vue-query'> & {
          * @see https://tanstack.com/query/v5/docs/framework/vue/reference/queryKey
          */
         name?: StringName;
+        /**
+         * Whether to include operation tags in query keys.
+         * This will make query keys larger but provides better cache invalidation capabilities.
+         *
+         * @default false
+         */
+        tags?: boolean;
       };
   /**
    * Configuration for generated query options helpers.
@@ -258,6 +272,13 @@ export type Config = Plugin.Name<'@tanstack/vue-query'> & {
      * @see https://tanstack.com/query/v5/docs/framework/vue/reference/infiniteQueryOptions
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in infinite query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated infinite query options helpers.
@@ -345,6 +366,13 @@ export type Config = Plugin.Name<'@tanstack/vue-query'> & {
      * @see https://tanstack.com/query/v5/docs/framework/vue/reference/queryKey
      */
     name: StringName;
+    /**
+     * Whether to include operation tags in query keys.
+     * This will make query keys larger but provides better cache invalidation capabilities.
+     *
+     * @default false
+     */
+    tags: boolean;
   };
   /**
    * Resolved configuration for generated query options helpers.


### PR DESCRIPTION
I think we fixed tanstack frontend invalidation forever by this PR
use case:
```ts
function predicate(query: Query) {
    return query.queryKey[0].tags?.includes('Resource');
}
```

thank you @mrlubos for such a wonderful lib