### PR TITLE
fix: resolve Yarn PnP compatibility issues with client bundle generation

### DIFF
--- a/.changeset/tiny-cobras-grow.md
+++ b/.changeset/tiny-cobras-grow.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix: resolve Yarn PnP compatibility issues with client bundle generation


### PR DESCRIPTION
Replace fs.cpSync with PnP-compatible recursive copy function to fix file copying from ZIP archives in Yarn PnP environments.

- Add copyRecursivePnP() function using fs.readFile/writeFile operations
- Replace all fs.cpSync calls in generateClientBundle()
- Maintain createRequire() for package root resolution
- Fix ENOENT errors when accessing /dist/clients/core in PnP

Fixes #2237, #2183