### PR TITLE
Add local option for Zod plugin datetime's

### DIFF
--- a/.changeset/stale-sloths-jog.md
+++ b/.changeset/stale-sloths-jog.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': patch
+---
+
+Adds local option for Zod's datetime options

--- a/.changeset/stale-sloths-jog.md
+++ b/.changeset/stale-sloths-jog.md
@@ -2,4 +2,4 @@
 '@hey-api/openapi-ts': patch
 ---
 
-Adds local option for Zod's datetime options
+fix(zod): add `dates.local` option to allow unqualified (timezone-less) datetimes

--- a/examples/openapi-ts-angular-common/angular.json
+++ b/examples/openapi-ts-angular-common/angular.json
@@ -88,5 +88,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/examples/openapi-ts-angular/angular.json
+++ b/examples/openapi-ts-angular/angular.json
@@ -88,5 +88,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/packages/openapi-ts/src/plugins/zod/config.ts
+++ b/packages/openapi-ts/src/plugins/zod/config.ts
@@ -67,6 +67,7 @@ export const defaultConfig: ZodPlugin['Config'] = {
 
     plugin.config.dates = context.valueToObject({
       defaultValue: {
+        local: false,
         offset: false,
       },
       value: plugin.config.dates,

--- a/packages/openapi-ts/src/plugins/zod/mini/plugin.ts
+++ b/packages/openapi-ts/src/plugins/zod/mini/plugin.ts
@@ -536,6 +536,15 @@ const stringTypeToZodSchema = ({
     }),
   });
 
+  const dateTimeOptions: { key: string; value: boolean }[] = [];
+
+  if (plugin.config.dates.offset) {
+    dateTimeOptions.push({ key: 'offset', value: true });
+  }
+  if (plugin.config.dates.local) {
+    dateTimeOptions.push({ key: 'local', value: true });
+  }
+
   if (schema.format) {
     switch (schema.format) {
       case 'date':
@@ -558,18 +567,14 @@ const stringTypeToZodSchema = ({
             }),
             name: identifiers.datetime,
           }),
-          parameters: plugin.config.dates.offset
-            ? [
-                tsc.objectExpression({
-                  obj: [
-                    {
-                      key: 'offset',
-                      value: true,
-                    },
-                  ],
-                }),
-              ]
-            : [],
+          parameters:
+            dateTimeOptions.length > 0
+              ? [
+                  tsc.objectExpression({
+                    obj: dateTimeOptions,
+                  }),
+                ]
+              : [],
         });
         break;
       case 'email':

--- a/packages/openapi-ts/src/plugins/zod/types.d.ts
+++ b/packages/openapi-ts/src/plugins/zod/types.d.ts
@@ -34,6 +34,15 @@ export type UserConfig = Plugin.Name<'zod'> & {
    */
   dates?: {
     /**
+     * Whether to allow unqualified (timezone-less) datetimes:
+     *
+     * When enabled, Zod will accept datetime strings without timezone information.
+     * When disabled, Zod will require timezone information in datetime strings.
+     *
+     * @default false
+     */
+    local?: boolean;
+    /**
      * Whether to include timezone offset information when handling dates.
      *
      * When enabled, date strings will preserve timezone information.
@@ -365,6 +374,15 @@ export type Config = Plugin.Name<'zod'> & {
    * date validation features.
    */
   dates: {
+    /**
+     * Whether to allow unqualified (timezone-less) datetimes:
+     *
+     * When enabled, Zod will accept datetime strings without timezone information.
+     * When disabled, Zod will require timezone information in datetime strings.
+     *
+     * @default false
+     */
+    local: boolean;
     /**
      * Whether to include timezone offset information when handling dates.
      *

--- a/packages/openapi-ts/src/plugins/zod/v3/plugin.ts
+++ b/packages/openapi-ts/src/plugins/zod/v3/plugin.ts
@@ -449,6 +449,15 @@ const stringTypeToZodSchema = ({
     }),
   });
 
+  const dateTimeOptions: { key: string; value: boolean }[] = [];
+
+  if (plugin.config.dates.offset) {
+    dateTimeOptions.push({ key: 'offset', value: true });
+  }
+  if (plugin.config.dates.local) {
+    dateTimeOptions.push({ key: 'local', value: true });
+  }
+
   if (schema.format) {
     switch (schema.format) {
       case 'date':
@@ -465,18 +474,14 @@ const stringTypeToZodSchema = ({
             expression: stringExpression,
             name: identifiers.datetime,
           }),
-          parameters: plugin.config.dates.offset
-            ? [
-                tsc.objectExpression({
-                  obj: [
-                    {
-                      key: 'offset',
-                      value: true,
-                    },
-                  ],
-                }),
-              ]
-            : [],
+          parameters:
+            dateTimeOptions.length > 0
+              ? [
+                  tsc.objectExpression({
+                    obj: dateTimeOptions,
+                  }),
+                ]
+              : [],
         });
         break;
       case 'email':

--- a/packages/openapi-ts/src/plugins/zod/v4/plugin.ts
+++ b/packages/openapi-ts/src/plugins/zod/v4/plugin.ts
@@ -515,6 +515,15 @@ const stringTypeToZodSchema = ({
     }),
   });
 
+  const dateTimeOptions: { key: string; value: boolean }[] = [];
+
+  if (plugin.config.dates.offset) {
+    dateTimeOptions.push({ key: 'offset', value: true });
+  }
+  if (plugin.config.dates.local) {
+    dateTimeOptions.push({ key: 'local', value: true });
+  }
+
   if (schema.format) {
     switch (schema.format) {
       case 'date':
@@ -537,18 +546,14 @@ const stringTypeToZodSchema = ({
             }),
             name: identifiers.datetime,
           }),
-          parameters: plugin.config.dates.offset
-            ? [
-                tsc.objectExpression({
-                  obj: [
-                    {
-                      key: 'offset',
-                      value: true,
-                    },
-                  ],
-                }),
-              ]
-            : [],
+          parameters:
+            dateTimeOptions.length > 0
+              ? [
+                  tsc.objectExpression({
+                    obj: dateTimeOptions,
+                  }),
+                ]
+              : [],
         });
         break;
       case 'email':


### PR DESCRIPTION
Adds the local option to z.datetime in accordance with the docs on https://zod.dev/api?id=iso-datetimes.
Enabling serialization/validation of datetimes without trailing "Z". 

Thanks for a great lib and a great initiative! ⭐ @mrlubos 