### PR TITLE
Non ascii discriminator mapping fix

### DIFF
--- a/.changeset/two-toys-join.md
+++ b/.changeset/two-toys-join.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(parser): handle non-ascii characters in discriminator

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-any-of/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-any-of/types.gen.ts
@@ -10,6 +10,8 @@ export type Baz = Qux;
 
 export type Bar = Qux;
 
+export type Spæcial = Qux;
+
 export type Qux = {
     id: string;
     type: Quux;
@@ -21,7 +23,9 @@ export type Quuz = ({
     type?: 'bar';
 } & Bar) | ({
     type?: 'baz';
-} & Baz);
+} & Baz) | ({
+    type?: 'non-ascii';
+} & Spæcial);
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-mapped-many/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-mapped-many/types.gen.ts
@@ -4,7 +4,9 @@ export type Foo = ({
     foo: 'one' | 'two';
 } & Bar) | ({
     foo: 'three';
-} & Baz);
+} & Baz) | ({
+    foo: 'four';
+} & Spæcial);
 
 export type Bar = {
     foo?: 'one' | 'two';
@@ -12,6 +14,10 @@ export type Bar = {
 
 export type Baz = {
     foo?: 'three';
+};
+
+export type Spæcial = {
+    foo?: 'four';
 };
 
 export type ClientOptions = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-one-of/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-one-of/types.gen.ts
@@ -10,6 +10,8 @@ export type Baz = Qux;
 
 export type Bar = Qux;
 
+export type Spæcial = Qux;
+
 export type Qux = {
     id: string;
     type: Quux;
@@ -21,7 +23,9 @@ export type Quuz = ({
     type: 'bar';
 } & Bar) | ({
     type: 'baz';
-} & Baz);
+} & Baz) | ({
+    type: 'non-ascii';
+} & Spæcial);
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-any-of/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-any-of/types.gen.ts
@@ -10,6 +10,8 @@ export type Baz = Qux;
 
 export type Bar = Qux;
 
+export type Spæcial = Qux;
+
 export type Qux = {
     id: string;
     type: Quux;
@@ -21,7 +23,9 @@ export type Quuz = ({
     type?: 'bar';
 } & Bar) | ({
     type?: 'baz';
-} & Baz);
+} & Baz) | ({
+    type?: 'non-ascii';
+} & Spæcial);
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-mapped-many/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-mapped-many/types.gen.ts
@@ -4,7 +4,9 @@ export type Foo = ({
     foo: 'one' | 'two';
 } & Bar) | ({
     foo: 'three';
-} & Baz);
+} & Baz) | ({
+    foo: 'four';
+} & Spæcial);
 
 export type Bar = {
     foo?: 'one' | 'two';
@@ -12,6 +14,10 @@ export type Bar = {
 
 export type Baz = {
     foo?: 'three';
+};
+
+export type Spæcial = {
+    foo?: 'four';
 };
 
 export type ClientOptions = {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-one-of/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-one-of/types.gen.ts
@@ -10,6 +10,8 @@ export type Baz = Qux;
 
 export type Bar = Qux;
 
+export type Spæcial = Qux;
+
 export type Qux = {
     id: string;
     type: Quux;
@@ -21,7 +23,9 @@ export type Quuz = ({
     type: 'bar';
 } & Bar) | ({
     type: 'baz';
-} & Baz);
+} & Baz) | ({
+    type: 'non-ascii';
+} & Spæcial);
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/specs/3.0.x/discriminator-any-of.yaml
+++ b/packages/openapi-ts-tests/specs/3.0.x/discriminator-any-of.yaml
@@ -16,6 +16,9 @@ components:
     Bar:
       allOf:
         - $ref: '#/components/schemas/Qux'
+    Spæcial:
+      allOf:
+        - $ref: '#/components/schemas/Qux'
     Qux:
       type: object
       properties:
@@ -35,8 +38,10 @@ components:
       anyOf:
         - $ref: '#/components/schemas/Bar'
         - $ref: '#/components/schemas/Baz'
+        - $ref: '#/components/schemas/Spæcial'
       discriminator:
         propertyName: type
         mapping:
           bar: '#/components/schemas/Bar'
           baz: '#/components/schemas/Baz'
+          'non-ascii': '#/components/schemas/Spæcial'

--- a/packages/openapi-ts-tests/specs/3.0.x/discriminator-mapped-many.yaml
+++ b/packages/openapi-ts-tests/specs/3.0.x/discriminator-mapped-many.yaml
@@ -8,12 +8,14 @@ components:
       oneOf:
         - $ref: '#/components/schemas/Bar'
         - $ref: '#/components/schemas/Baz'
+        - $ref: '#/components/schemas/Spæcial'
       discriminator:
         propertyName: foo
         mapping:
           one: '#/components/schemas/Bar'
           two: '#/components/schemas/Bar'
           three: '#/components/schemas/Baz'
+          four: '#/components/schemas/Spæcial'
     Bar:
       type: object
       properties:
@@ -29,3 +31,10 @@ components:
           type: string
           enum:
             - three
+    Spæcial:
+      type: object
+      properties:
+        foo:
+          type: string
+          enum:
+            - four

--- a/packages/openapi-ts-tests/specs/3.0.x/discriminator-one-of.yaml
+++ b/packages/openapi-ts-tests/specs/3.0.x/discriminator-one-of.yaml
@@ -16,6 +16,9 @@ components:
     Bar:
       allOf:
         - $ref: '#/components/schemas/Qux'
+    Spæcial:
+      allOf:
+        - $ref: '#/components/schemas/Qux'
     Qux:
       type: object
       properties:
@@ -35,8 +38,10 @@ components:
       oneOf:
         - $ref: '#/components/schemas/Bar'
         - $ref: '#/components/schemas/Baz'
+        - $ref: '#/components/schemas/Spæcial'
       discriminator:
         propertyName: type
         mapping:
           bar: '#/components/schemas/Bar'
           baz: '#/components/schemas/Baz'
+          'non-ascii': '#/components/schemas/Spæcial'

--- a/packages/openapi-ts-tests/specs/3.1.x/discriminator-any-of.yaml
+++ b/packages/openapi-ts-tests/specs/3.1.x/discriminator-any-of.yaml
@@ -16,6 +16,9 @@ components:
     Bar:
       allOf:
         - $ref: '#/components/schemas/Qux'
+    Spæcial:
+      allOf:
+        - $ref: '#/components/schemas/Qux'
     Qux:
       type: object
       properties:
@@ -35,8 +38,10 @@ components:
       anyOf:
         - $ref: '#/components/schemas/Bar'
         - $ref: '#/components/schemas/Baz'
+        - $ref: '#/components/schemas/Spæcial'
       discriminator:
         propertyName: type
         mapping:
           bar: '#/components/schemas/Bar'
           baz: '#/components/schemas/Baz'
+          'non-ascii': '#/components/schemas/Spæcial'

--- a/packages/openapi-ts-tests/specs/3.1.x/discriminator-mapped-many.yaml
+++ b/packages/openapi-ts-tests/specs/3.1.x/discriminator-mapped-many.yaml
@@ -8,12 +8,14 @@ components:
       oneOf:
         - $ref: '#/components/schemas/Bar'
         - $ref: '#/components/schemas/Baz'
+        - $ref: '#/components/schemas/Spæcial'
       discriminator:
         propertyName: foo
         mapping:
           one: '#/components/schemas/Bar'
           two: '#/components/schemas/Bar'
           three: '#/components/schemas/Baz'
+          four: '#/components/schemas/Spæcial'
     Bar:
       type: object
       properties:
@@ -29,3 +31,10 @@ components:
           type: string
           enum:
             - three
+    Spæcial:
+      type: object
+      properties:
+        foo:
+          type: string
+          enum:
+            - four

--- a/packages/openapi-ts-tests/specs/3.1.x/discriminator-one-of.yaml
+++ b/packages/openapi-ts-tests/specs/3.1.x/discriminator-one-of.yaml
@@ -16,6 +16,9 @@ components:
     Bar:
       allOf:
         - $ref: '#/components/schemas/Qux'
+    Spæcial:
+      allOf:
+        - $ref: '#/components/schemas/Qux'
     Qux:
       type: object
       properties:
@@ -35,8 +38,10 @@ components:
       oneOf:
         - $ref: '#/components/schemas/Bar'
         - $ref: '#/components/schemas/Baz'
+        - $ref: '#/components/schemas/Spæcial'
       discriminator:
         propertyName: type
         mapping:
           bar: '#/components/schemas/Bar'
           baz: '#/components/schemas/Baz'
+          'non-ascii': '#/components/schemas/Spæcial'

--- a/packages/openapi-ts/src/openApi/3.0.x/parser/schema.ts
+++ b/packages/openapi-ts/src/openApi/3.0.x/parser/schema.ts
@@ -538,9 +538,9 @@ const parseAnyOf = ({
     );
 
     // `$ref` should be defined with discriminators
-    if (schema.discriminator && '$ref' in compositionSchema) {
+    if (schema.discriminator && irCompositionSchema.$ref != null) {
       const values = discriminatorValues(
-        compositionSchema.$ref,
+        irCompositionSchema.$ref,
         schema.discriminator.mapping,
       );
       const valueSchemas: ReadonlyArray<IR.SchemaObject> = values.map(
@@ -719,9 +719,9 @@ const parseOneOf = ({
     );
 
     // `$ref` should be defined with discriminators
-    if (schema.discriminator && '$ref' in compositionSchema) {
+    if (schema.discriminator && irCompositionSchema.$ref != null) {
       const values = discriminatorValues(
-        compositionSchema.$ref,
+        irCompositionSchema.$ref,
         schema.discriminator.mapping,
       );
       const valueSchemas: ReadonlyArray<IR.SchemaObject> = values.map(

--- a/packages/openapi-ts/src/openApi/3.1.x/parser/schema.ts
+++ b/packages/openapi-ts/src/openApi/3.1.x/parser/schema.ts
@@ -541,9 +541,9 @@ const parseAnyOf = ({
     });
 
     // `$ref` should be defined with discriminators
-    if (schema.discriminator && compositionSchema.$ref) {
+    if (schema.discriminator && irCompositionSchema.$ref != null) {
       const values = discriminatorValues(
-        compositionSchema.$ref,
+        irCompositionSchema.$ref,
         schema.discriminator.mapping,
       );
       const valueSchemas: ReadonlyArray<IR.SchemaObject> = values.map(
@@ -697,9 +697,9 @@ const parseOneOf = ({
     });
 
     // `$ref` should be defined with discriminators
-    if (schema.discriminator && compositionSchema.$ref) {
+    if (schema.discriminator && irCompositionSchema.$ref != null) {
       const values = discriminatorValues(
-        compositionSchema.$ref,
+        irCompositionSchema.$ref,
         schema.discriminator.mapping,
       );
       const valueSchemas: ReadonlyArray<IR.SchemaObject> = values.map(


### PR DESCRIPTION
If a type name referenced in a discriminator mapping has non-ascii characters, the resolving of the mapping into a union type failed because the $ref value used in the lookup was uri encoded, and the typename in the lookup was not.

This change fixes that by using the $ref value which has been uri decoded for the lookup.

