### PR TITLE
fix: handle discriminator could be extending it

### DIFF
--- a/.changeset/forty-seals-explode.md
+++ b/.changeset/forty-seals-explode.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(parser): correctly handle schema extending discriminated schema

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-all-of/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-all-of/types.gen.ts
@@ -44,6 +44,26 @@ export type QuxMapped = FooMapped & {
     qux?: boolean;
 };
 
+export type FooUnion = ({
+    id: 'bar';
+} & BarUnion) | ({
+    id: 'baz';
+} & BazUnion);
+
+export type BarUnion = {
+    id?: string;
+    bar?: string;
+};
+
+export type BazUnion = {
+    id?: string;
+    baz?: string;
+};
+
+export type QuxExtend = FooUnion & {
+    id?: 'QuxExtend';
+};
+
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});
 };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-all-of/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/discriminator-all-of/types.gen.ts
@@ -60,9 +60,7 @@ export type BazUnion = {
     baz?: string;
 };
 
-export type QuxExtend = FooUnion & {
-    id?: 'QuxExtend';
-};
+export type QuxExtend = FooUnion;
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-all-of/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-all-of/types.gen.ts
@@ -44,6 +44,26 @@ export type QuxMapped = FooMapped & {
     qux?: boolean;
 };
 
+export type FooUnion = ({
+    id: 'bar';
+} & BarUnion) | ({
+    id: 'baz';
+} & BazUnion);
+
+export type BarUnion = {
+    id?: string;
+    bar?: string;
+};
+
+export type BazUnion = {
+    id?: string;
+    baz?: string;
+};
+
+export type QuxExtend = FooUnion & {
+    id?: 'QuxExtend';
+};
+
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});
 };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-all-of/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/discriminator-all-of/types.gen.ts
@@ -60,9 +60,7 @@ export type BazUnion = {
     baz?: string;
 };
 
-export type QuxExtend = FooUnion & {
-    id?: 'QuxExtend';
-};
+export type QuxExtend = FooUnion;
 
 export type ClientOptions = {
     baseUrl: `${string}://${string}` | (string & {});

--- a/packages/openapi-ts-tests/specs/3.0.x/discriminator-all-of.yaml
+++ b/packages/openapi-ts-tests/specs/3.0.x/discriminator-all-of.yaml
@@ -67,3 +67,29 @@ components:
           properties:
             qux:
               type: boolean
+    FooUnion:
+      oneOf:
+        - $ref: '#/components/schemas/BarUnion'
+        - $ref: '#/components/schemas/BazUnion'
+      discriminator:
+        propertyName: id
+        mapping:
+          bar: '#/components/schemas/BarUnion'
+          baz: '#/components/schemas/BazUnion'
+    BarUnion:
+      type: object
+      properties:
+        id:
+          type: string
+        bar:
+          type: string
+    BazUnion:
+      type: object
+      properties:
+        id:
+          type: string
+        baz:
+          type: string
+    QuxExtend: # this is a schema that extends the FooUnion schema
+      allOf:
+        - $ref: '#/components/schemas/FooUnion'

--- a/packages/openapi-ts-tests/specs/3.1.x/discriminator-all-of.yaml
+++ b/packages/openapi-ts-tests/specs/3.1.x/discriminator-all-of.yaml
@@ -67,3 +67,29 @@ components:
           properties:
             qux:
               type: boolean
+    FooUnion:
+      oneOf:
+        - $ref: '#/components/schemas/BarUnion'
+        - $ref: '#/components/schemas/BazUnion'
+      discriminator:
+        propertyName: id
+        mapping:
+          bar: '#/components/schemas/BarUnion'
+          baz: '#/components/schemas/BazUnion'
+    BarUnion:
+      type: object
+      properties:
+        id:
+          type: string
+        bar:
+          type: string
+    BazUnion:
+      type: object
+      properties:
+        id:
+          type: string
+        baz:
+          type: string
+    QuxExtend: # this is a schema that extends the FooUnion schema
+      allOf:
+        - $ref: '#/components/schemas/FooUnion'

--- a/packages/openapi-ts/src/openApi/3.0.x/parser/schema.ts
+++ b/packages/openapi-ts/src/openApi/3.0.x/parser/schema.ts
@@ -372,29 +372,38 @@ const parseAllOf = ({
         const values = discriminatorValues(
           state.$ref,
           ref.discriminator.mapping,
+          // If the ref has oneOf, we only use the schema name as the value
+          // only if current schema is part of the oneOf. Else it is extending
+          // the ref schema
+          ref.oneOf
+            ? () => ref.oneOf!.some((o) => '$ref' in o && o.$ref === state.$ref)
+            : undefined,
         );
-        const valueSchemas: ReadonlyArray<IR.SchemaObject> = values.map(
-          (value) => ({
-            const: value,
-            type: 'string',
-          }),
-        );
-        const irDiscriminatorSchema: IR.SchemaObject = {
-          properties: {
-            [ref.discriminator.propertyName]:
-              valueSchemas.length > 1
-                ? {
-                    items: valueSchemas,
-                    logicalOperator: 'or',
-                  }
-                : valueSchemas[0]!,
-          },
-          type: 'object',
-        };
-        if (ref.required?.includes(ref.discriminator.propertyName)) {
-          irDiscriminatorSchema.required = [ref.discriminator.propertyName];
+
+        if (values.length > 0) {
+          const valueSchemas: ReadonlyArray<IR.SchemaObject> = values.map(
+            (value) => ({
+              const: value,
+              type: 'string',
+            }),
+          );
+          const irDiscriminatorSchema: IR.SchemaObject = {
+            properties: {
+              [ref.discriminator.propertyName]:
+                valueSchemas.length > 1
+                  ? {
+                      items: valueSchemas,
+                      logicalOperator: 'or',
+                    }
+                  : valueSchemas[0]!,
+            },
+            type: 'object',
+          };
+          if (ref.required?.includes(ref.discriminator.propertyName)) {
+            irDiscriminatorSchema.required = [ref.discriminator.propertyName];
+          }
+          schemaItems.push(irDiscriminatorSchema);
         }
-        schemaItems.push(irDiscriminatorSchema);
       }
 
       if (!state.circularReferenceTracker.has(compositionSchema.$ref)) {

--- a/packages/openapi-ts/src/openApi/3.1.x/parser/schema.ts
+++ b/packages/openapi-ts/src/openApi/3.1.x/parser/schema.ts
@@ -405,29 +405,37 @@ const parseAllOf = ({
         const values = discriminatorValues(
           state.$ref,
           ref.discriminator.mapping,
+          // If the ref has oneOf, we only use the schema name as the value
+          // only if current schema is part of the oneOf. Else it is extending
+          // the ref schema
+          ref.oneOf
+            ? () => ref.oneOf!.some((o) => '$ref' in o && o.$ref === state.$ref)
+            : undefined,
         );
-        const valueSchemas: ReadonlyArray<IR.SchemaObject> = values.map(
-          (value) => ({
-            const: value,
-            type: 'string',
-          }),
-        );
-        const irDiscriminatorSchema: IR.SchemaObject = {
-          properties: {
-            [ref.discriminator.propertyName]:
-              valueSchemas.length > 1
-                ? {
-                    items: valueSchemas,
-                    logicalOperator: 'or',
-                  }
-                : valueSchemas[0]!,
-          },
-          type: 'object',
-        };
-        if (ref.required?.includes(ref.discriminator.propertyName)) {
-          irDiscriminatorSchema.required = [ref.discriminator.propertyName];
+        if (values.length > 0) {
+          const valueSchemas: ReadonlyArray<IR.SchemaObject> = values.map(
+            (value) => ({
+              const: value,
+              type: 'string',
+            }),
+          );
+          const irDiscriminatorSchema: IR.SchemaObject = {
+            properties: {
+              [ref.discriminator.propertyName]:
+                valueSchemas.length > 1
+                  ? {
+                      items: valueSchemas,
+                      logicalOperator: 'or',
+                    }
+                  : valueSchemas[0]!,
+            },
+            type: 'object',
+          };
+          if (ref.required?.includes(ref.discriminator.propertyName)) {
+            irDiscriminatorSchema.required = [ref.discriminator.propertyName];
+          }
+          schemaItems.push(irDiscriminatorSchema);
         }
-        schemaItems.push(irDiscriminatorSchema);
       }
 
       if (!state.circularReferenceTracker.has(compositionSchema.$ref)) {

--- a/packages/openapi-ts/src/openApi/shared/utils/discriminator.ts
+++ b/packages/openapi-ts/src/openApi/shared/utils/discriminator.ts
@@ -3,6 +3,7 @@ import { refToName } from '../../../utils/ref';
 export const discriminatorValues = (
   $ref: string,
   mapping?: Record<string, string>,
+  shouldUseRefAsValue?: () => boolean,
 ): ReadonlyArray<string> => {
   const values: Array<string> = [];
 
@@ -12,7 +13,7 @@ export const discriminatorValues = (
     }
   }
 
-  if (!values.length) {
+  if (!values.length && (!shouldUseRefAsValue || shouldUseRefAsValue())) {
     return [refToName($ref)];
   }
 


### PR DESCRIPTION
Currently the code assumes when a schema X has a `allOf` reference to another schema Y with `discriminator`, then schema X should respects that `discriminator` and add the `discriminator.type` with value set to the schema name of X (if there is no `discriminator.mapping refer to schema X).

However, schema X could also be extending schema Y, and in that case it should not add the `discriminator.type` property.

See first commit for the bug reproduction. It is causing `QuxExtend` type to becomes `never`.

See second commit for the fix. The assumption is if schema Y has `oneOf` and `oneOf` doesn't include schema X, then X is extending Y so it should not add `discriminator.type` to itself.