### PR TITLE
fix(client): node compatible `mergeHeaders`

### DIFF
--- a/.changeset/metal-brooms-yawn.md
+++ b/.changeset/metal-brooms-yawn.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+fix(client): `mergeHeaders` functions use `.forEach()` instead of `.entries()`

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-valibot/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-valibot/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-zod/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-zod/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/group-by-tag/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/group-by-tag/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-valibot/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-valibot/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-zod/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-zod/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/group-by-tag/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/group-by-tag/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-valibot/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-valibot/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-zod/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-zod/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/group-by-tag/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/group-by-tag/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/utils.gen.ts
@@ -295,6 +295,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -305,7 +313,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/utils.gen.ts
@@ -252,6 +252,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -268,7 +276,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/plugins/@tanstack/meta/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/plugins/@tanstack/meta/client/utils.gen.ts
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/test/generated/v3_no_index/client/utils.gen.ts.snap
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/test/generated/v3_no_index/client/utils.gen.ts.snap
@@ -183,17 +183,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/utils.ts
@@ -181,17 +181,27 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
   const mergedHeaders = new Headers();
   for (const header of headers) {
-    if (!header || typeof header !== 'object') {
+    if (!header) {
       continue;
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/utils.ts
@@ -293,6 +293,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -303,7 +311,9 @@ export const mergeHeaders = (
     }
 
     const iterator =
-      header instanceof Headers ? header.entries() : Object.entries(header);
+      header instanceof Headers
+        ? headersEntries(header)
+        : Object.entries(header);
 
     for (const [key, value] of iterator) {
       if (value === null) {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/utils.ts
@@ -250,6 +250,14 @@ export const mergeConfigs = (a: Config, b: Config): Config => {
   return config;
 };
 
+const headersEntries = (headers: Headers): Array<[string, string]> => {
+  const entries: Array<[string, string]> = [];
+  headers.forEach((value, key) => {
+    entries.push([key, value]);
+  });
+  return entries;
+};
+
 export const mergeHeaders = (
   ...headers: Array<Required<Config>['headers'] | undefined>
 ): Headers => {
@@ -266,7 +274,7 @@ export const mergeHeaders = (
 
     const iterator =
       h instanceof Headers
-        ? h.entries()
+        ? headersEntries(h)
         : Object.entries(h as Record<string, unknown>);
 
     for (const [key, value] of iterator) {


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/2230
Closes https://github.com/hey-api/openapi-ts/issues/2521
Related https://github.com/hey-api/openapi-ts/issues/2539

Alternatively, I think the cleanest approach would be to handle `Header` instances separately, as they always contain `string` as values.