### PR TITLE
fix: handle flat params structure in operation config

### DIFF
--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/__tests__/params.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/__tests__/params.test.ts
@@ -346,6 +346,101 @@ describe('buildClientParams', () => {
       description: 'strip empty slots',
       params: {},
     },
+    {
+      args: [
+        {
+          id: '1335279038599663729',
+        },
+      ],
+      config: [
+        {
+          args: [
+            {
+              in: 'path',
+              key: 'id',
+            },
+          ],
+        },
+      ],
+      description: 'flat path parameter (issue #2984)',
+      params: {
+        path: {
+          id: '1335279038599663729',
+        },
+      },
+    },
+    {
+      args: [
+        {
+          id: 'ses_123',
+          messageID: 'msg_456',
+        },
+      ],
+      config: [
+        {
+          args: [
+            {
+              in: 'path',
+              key: 'id',
+            },
+            {
+              in: 'path',
+              key: 'messageID',
+            },
+          ],
+        },
+      ],
+      description: 'flat multiple path parameters',
+      params: {
+        path: {
+          id: 'ses_123',
+          messageID: 'msg_456',
+        },
+      },
+    },
+    {
+      args: [
+        {
+          id: 'ses_123',
+          messageID: 'msg_456',
+          modelID: 'gpt-4',
+          providerID: 'openai',
+        },
+      ],
+      config: [
+        {
+          args: [
+            {
+              in: 'path',
+              key: 'id',
+            },
+            {
+              in: 'body',
+              key: 'messageID',
+            },
+            {
+              in: 'body',
+              key: 'modelID',
+            },
+            {
+              in: 'body',
+              key: 'providerID',
+            },
+          ],
+        },
+      ],
+      description: 'flat mixed path and body parameters',
+      params: {
+        body: {
+          messageID: 'msg_456',
+          modelID: 'gpt-4',
+          providerID: 'openai',
+        },
+        path: {
+          id: 'ses_123',
+        },
+      },
+    },
   ];
 
   it.each(scenarios)('$description', async ({ args, config, params }) => {


### PR DESCRIPTION
## Summary
- Fixes issue where flat parameter structure wasn't properly wrapped in operation config
- Adds comprehensive test cases for flat path parameters and mixed path/body parameters

## Changes
- Wraps parameter fields in an 'args' array when using flat params structure
- Adds test case for single flat path parameter (issue #2984)
- Adds test case for multiple flat path parameters
- Adds test case for mixed flat path and body parameters

This ensures that flat parameter structures are correctly formatted in the operation configuration, allowing the client to properly extract and map parameters.