### PR TITLE
Fix: In axios client, proving NO paramsSerializer should use the `query` option for params

### DIFF
--- a/.changeset/forty-jobs-sneeze.md
+++ b/.changeset/forty-jobs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**clients(axios)**: use `query` option when no `paramsSerializer` is provided

--- a/examples/openapi-ts-axios/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-axios/src/client/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/clean-false/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/import-file-extension-ts/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 

--- a/packages/openapi-ts/package.json
+++ b/packages/openapi-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hey-api/openapi-ts",
-  "version": "0.89.1-0",
+  "version": "0.89.0",
   "description": "🚀 The OpenAPI to TypeScript codegen. Generate clients, SDKs, validators, and more.",
   "homepage": "https://heyapi.dev/",
   "repository": {

--- a/packages/openapi-ts/package.json
+++ b/packages/openapi-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hey-api/openapi-ts",
-  "version": "0.89.0",
+  "version": "0.89.1-0",
   "description": "🚀 The OpenAPI to TypeScript codegen. Generate clients, SDKs, validators, and more.",
   "homepage": "https://heyapi.dev/",
   "repository": {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-axios/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-axios/__tests__/client.test.ts
@@ -49,6 +49,49 @@ describe('buildUrl', () => {
   it.each(scenarios)('returns $url', ({ options, url }) => {
     expect(client.buildUrl(options)).toBe(url);
   });
+
+  it.each(scenarios)(
+    'correctly maps `query` parameter to `params` parameter for axios',
+    async ({ options }) => {
+      const mockAxios = vi.fn((config) => ({ config }));
+
+      expect(
+        (
+          await client.request({
+            ...options,
+            axios: mockAxios as Partial<AxiosInstance> as AxiosInstance,
+            method: 'GET',
+          })
+        ).config?.params,
+      ).toBe(options.query);
+    },
+  );
+
+  it.each(scenarios)(
+    'uses a custom `paramsSerializer` method when given and do not map `params` for axios',
+    async ({ options }) => {
+      const mockAxios = vi.fn((config) => ({ config }));
+
+      const paramsSerializer = (params: Record<string, string>) =>
+        new URLSearchParams(params).toString();
+
+      expect(
+        (
+          await client.request({
+            ...options,
+            axios: mockAxios as Partial<AxiosInstance> as AxiosInstance,
+            method: 'GET',
+            paramsSerializer,
+          })
+        ).config,
+      ).toEqual(
+        expect.objectContaining({
+          params: undefined,
+          paramsSerializer,
+        }),
+      );
+    },
+  );
 });
 
 describe('AxiosInstance', () => {
@@ -350,5 +393,14 @@ describe('confirming axios behaviour for constructing URLs', () => {
 
     const config = client.getUri({ baseURL: undefined, url: '/users' });
     expect(config).toBe('https://api.example.com/users');
+  });
+  it('does append `params` as searchParams to the URL', async () => {
+    const client = axios.create({
+      baseURL: 'https://api.example.com',
+      params: { foo: 'bar' },
+    });
+
+    const config = client.getUri({ baseURL: undefined, url: '/users' });
+    expect(config).toBe('https://api.example.com/users?foo=bar');
   });
 });

--- a/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/client.ts
@@ -82,7 +82,7 @@ export const createClient = (config: Config = {}): Client => {
         data: getValidRequestBody(opts),
         headers: opts.headers as RawAxiosRequestHeaders,
         // let `paramsSerializer()` handle query params if it exists
-        params: opts.paramsSerializer ? opts.query : undefined,
+        params: !opts.paramsSerializer ? opts.query : undefined,
         url,
       });
 


### PR DESCRIPTION
Using the axios-client the provided `query` option in a GET request was not passed to axios, so it was not included in Request URL.

Reproduce:
```ts
  await clientXYZ.sdk.somethingGet({
        query: {
          myParam: "foo"
        },
      });
```
The requested URL will look like `GET https://example.org/something` so the "?myParam=foo" is missing