### PR TITLE
fix: use serialized body in SSE client requests

### DIFF
--- a/.changeset/brave-heads-battle.md
+++ b/.changeset/brave-heads-battle.md
@@ -1,0 +1,5 @@
+---
+'@hey-api/openapi-ts': minor
+---
+
+Fix body serialization for sse client

--- a/examples/openapi-ts-angular-common/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-angular-common/src/client/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-angular/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-angular/src/client/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-axios/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-axios/src/client/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/examples/openapi-ts-fastify/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-fetch/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-ky/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-ky/src/client/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-next/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-next/src/client/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-openai/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-openai/src/client/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-pinia-colada/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/client/client.gen.ts
@@ -247,6 +247,7 @@ export const createClient = (config: Config = {}): Client => {
         }
         return request
       },
+      serializedBody: getValidRequestBody(opts) as BodyInit | null | undefined,
       url
     })
   }

--- a/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-tanstack-react-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/examples/openapi-ts-tanstack-vue-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/client/client.gen.ts
@@ -247,6 +247,7 @@ export const createClient = (config: Config = {}): Client => {
         }
         return request
       },
+      serializedBody: getValidRequestBody(opts) as BodyInit | null | undefined,
       url
     })
   }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/content-types/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false-axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-false/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-number/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-strict/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/base-url-string/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/clean-false/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/default/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/import-file-extension-ts/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-optional/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/sdk-client-required/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-node16-sdk/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-axios/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -307,6 +307,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen.ts';
 import type { HttpMethod } from '../core/types.gen.ts';
+import { getValidRequestBody } from '../core/utils.gen.ts';
 import type { Client, Config, RequestOptions } from './types.gen.ts';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen.js';
 import type { HttpMethod } from '../core/types.gen.js';
+import { getValidRequestBody } from '../core/utils.gen.js';
 import type { Client, Config, RequestOptions } from './types.gen.js';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen.js';
 import type { HttpMethod } from '../core/types.gen.js';
+import { getValidRequestBody } from '../core/utils.gen.js';
 import type { Client, Config, RequestOptions } from './types.gen.js';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/content-types/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false-axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/client.gen.ts
@@ -214,6 +214,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/client/client.gen.ts
@@ -127,6 +127,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/client.gen.ts
@@ -228,6 +228,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/client.gen.ts
@@ -10,6 +10,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../core/serverSentEvents.gen';
 import type { HttpMethod } from '../core/types.gen';
+import { getValidRequestBody } from '../core/utils.gen';
 import type { Client, Config, RequestOptions } from './types.gen';
 import {
   buildUrl,
@@ -195,6 +196,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/main/test/__snapshots__/plugins/@tanstack/meta/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/plugins/@tanstack/meta/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/client.gen.ts
@@ -267,6 +267,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/client.ts
@@ -212,6 +212,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as unknown as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-axios/bundle/client.ts
@@ -125,6 +125,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         headers: opts.headers as Record<string, string>,
         method,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         // @ts-expect-error
         signal: opts.signal,
         url,

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
@@ -265,6 +265,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/client.ts
@@ -305,6 +305,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/client.ts
@@ -226,6 +226,10 @@ export const createClient = (config: Config = {}): Client => {
           }
           return request;
         },
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         url,
       });
     };

--- a/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/client.ts
@@ -8,6 +8,7 @@ import { reactive, ref, watch } from 'vue';
 
 import { createSseClient } from '../../client-core/bundle/serverSentEvents';
 import type { HttpMethod } from '../../client-core/bundle/types';
+import { getValidRequestBody } from '../../client-core/bundle/utils';
 import type { Client, Config, RequestOptions } from './types';
 import {
   buildUrl,
@@ -193,6 +194,10 @@ export const createClient = (config: Config = {}): Client => {
         body: opts.body as BodyInit | null | undefined,
         method,
         onRequest: undefined,
+        serializedBody: getValidRequestBody(opts) as
+          | BodyInit
+          | null
+          | undefined,
         signal: unwrapRefs(opts.signal) as AbortSignal,
         url,
       });


### PR DESCRIPTION
SSE client calls were using raw `opts.body` instead of properly serialized body data, causing SSE requests with JSON bodies to send malformed data. Now correctly passes `serializedBody` (via `getValidRequestBody`) to `createSseClient` across all affected client adapters (fetch, angular, axios, ky, next, nuxt).