### PR TITLE
feat(tanstack-query): add symbol metadata to mutationOptions for plugin discoverability

### DIFF
--- a/.changeset/rare-coins-heal.md
+++ b/.changeset/rare-coins-heal.md
@@ -1,0 +1,9 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@tanstack/angular-query-experimental)**: index mutation options symbol
+**plugin(@tanstack/react-query)**: index mutation options symbol
+**plugin(@tanstack/solid-query)**: index mutation options symbol
+**plugin(@tanstack/svelte-query)**: index mutation options symbol
+**plugin(@tanstack/vue-query)**: index mutation options symbol

--- a/packages/openapi-ts/src/plugins/@tanstack/query-core/v5/mutationOptions.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/query-core/v5/mutationOptions.ts
@@ -58,6 +58,15 @@ export const createMutationOptions = ({
   const mutationOptionsFn = 'mutationOptions';
   const symbolMutationOptions = plugin.symbol(
     applyNaming(operation.id, plugin.config.mutationOptions),
+    {
+      meta: {
+        category: 'hook',
+        resource: 'operation',
+        resourceId: operation.id,
+        role: 'mutationOptions',
+        tool: plugin.name,
+      },
+    },
   );
   const statement = $.const(symbolMutationOptions)
     .export()


### PR DESCRIPTION
## Summary

This PR adds symbol metadata to `mutationOptions` to match the existing pattern used by `queryOptions`.

## Problem

Currently, `queryOptions` symbols are registered with metadata that allows other plugins to discover them using `plugin.querySymbol()`:

```typescript
// queryOptions.ts - has metadata ✅
const symbolQueryOptionsFn = plugin.symbol(
  applyNaming(operation.id, plugin.config.queryOptions),
  {
    meta: {
      category: 'hook',
      resource: 'operation',
      resourceId: operation.id,
      role: 'queryOptions',
      tool: plugin.name,
    },
  },
);