### PR TITLE
docs: add comments attribute to plugins section

### DIFF
--- a/docs/openapi-ts/plugins/typescript.md
+++ b/docs/openapi-ts/plugins/typescript.md
@@ -135,7 +135,8 @@ We recommend exporting enums as plain JavaScript objects. [TypeScript enums](htt
 By default, `@hey-api/typescript` will include comments in the generated code based on descriptions from your OpenAPI specification. If you want to reduce the size of your generated files or prefer cleaner output, you can disable comments.
 
 ::: code-group
- [enabled]
+
+```js [enabled]
 export default {
   input: 'hey-api/backend', // sign up at app.heyapi.dev
   output: 'src/client',
@@ -147,7 +148,9 @@ export default {
     },
   ],
 };
+```
 
+```js [disabled]
 export default {
   input: 'hey-api/backend', // sign up at app.heyapi.dev
   output: 'src/client',
@@ -159,6 +162,9 @@ export default {
     },
   ],
 };
+```
+
+:::
 
 ## API
 

--- a/docs/openapi-ts/plugins/typescript.md
+++ b/docs/openapi-ts/plugins/typescript.md
@@ -130,6 +130,36 @@ export default {
 
 We recommend exporting enums as plain JavaScript objects. [TypeScript enums](https://www.typescriptlang.org/docs/handbook/enums.html) are not a type-level extension of JavaScript and pose [typing challenges](https://dev.to/ivanzm123/dont-use-enums-in-typescript-they-are-very-dangerous-57bh).
 
+## Comments
+
+By default, `@hey-api/typescript` will include comments in the generated code based on descriptions from your OpenAPI specification. If you want to reduce the size of your generated files or prefer cleaner output, you can disable comments.
+
+::: code-group
+ [enabled]
+export default {
+  input: 'hey-api/backend', // sign up at app.heyapi.dev
+  output: 'src/client',
+  plugins: [
+    // ...other plugins
+    {
+      comments: true, // default // [!code ++]
+      name: '@hey-api/typescript',
+    },
+  ],
+};
+
+export default {
+  input: 'hey-api/backend', // sign up at app.heyapi.dev
+  output: 'src/client',
+  plugins: [
+    // ...other plugins
+    {
+      comments: false, // [!code ++]
+      name: '@hey-api/typescript',
+    },
+  ],
+};
+
 ## API
 
 You can view the complete list of options in the [UserConfig](https://github.com/hey-api/openapi-ts/blob/main/packages/openapi-ts/src/plugins/@hey-api/typescript/types.ts) interface.


### PR DESCRIPTION
## Summary

Adds documentation for the `comments` option introduced in #3317 to the `@hey-api/typescript` plugin documentation.

## Changes

- Added new "Comments" section to the TypeScript plugin documentation
- Documented the boolean `comments` option with code examples for both enabled (default) and disabled states
- Included practical use cases for when users might want to disable comments

## Related

- Closes #2714
- Implements documentation for #3317

## Preview

### Comments

By default, `@hey-api/typescript` will include comments in the generated code based on descriptions from your OpenAPI specification. If you want to reduce the size of your generated files or prefer cleaner output, you can disable comments.

**Options:**
| Value | Description |
|-------|-------------|
| `true` (default) | Include comments from OpenAPI descriptions in generated code |
| `false` | Strip comments from generated code |

**Use cases for disabling comments:**
- Reduce the size of generated files
- Build process already strips comments
- Prefer referencing the original OpenAPI specification for documentation