### PR TITLE
fix(client-nuxt): forward asyncDataOptions to useFetch/useLazyFetch

### DIFF
--- a/.changeset/fix-nuxt-async-data-options.md
+++ b/.changeset/fix-nuxt-async-data-options.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-nuxt)**: fix: forward `asyncDataOptions` to `useFetch` and `useLazyFetch`

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-false/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-number/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-strict/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/base-url-string/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/clean-false/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/default/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/import-file-extension-ts/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-optional/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/sdk-client-required/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-node16-sdk/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-nuxt/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-nuxt/client/client.gen.ts
@@ -144,8 +144,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>

--- a/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-nuxt/bundle/client.ts
@@ -142,8 +142,8 @@ export const createClient = (config: Config = {}): Client => {
         body.value = serializeBody(changed);
       });
       return composable === 'useLazyFetch'
-        ? useLazyFetch(() => buildUrl(opts), opts)
-        : useFetch(() => buildUrl(opts), opts);
+        ? useLazyFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions })
+        : useFetch(() => buildUrl(opts), { ...opts, ...asyncDataOptions });
     }
 
     const handler: any = () =>


### PR DESCRIPTION
## Summary

- `asyncDataOptions` (e.g. `{ immediate: false }`) is destructured out of request options on [line 56](https://github.com/hey-api/openapi-ts/blob/main/packages/openapi-ts/src/plugins/%40hey-api/client-nuxt/bundle/client.ts#L56) but only forwarded to `useAsyncData`/`useLazyAsyncData` (lines 158-167)
- The `useFetch`/`useLazyFetch` path (lines 144-146) passed only `opts`, silently ignoring `asyncDataOptions`
- This caused `immediate: false` to be a no-op — fetches fired immediately regardless
- Fix: spread `asyncDataOptions` into the options object passed to `useFetch`/`useLazyFetch`. Nuxt's `useFetch` accepts these as top-level keys (`immediate`, `watch`, `default`, `transform`, etc.) since it's a wrapper around `useAsyncData` + `$fetch`

Closes #1966

## Test plan

- [x] Verified fix in a Nuxt app: all 4 composables (`useFetch`, `useLazyFetch`, `useAsyncData`, `useLazyAsyncData`) now correctly respect `immediate: false`
- [ ] CI snapshot tests pass (snapshots updated in this PR)