### PR TITLE
fix issue where body can be empty data on a put/post

### DIFF
--- a/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/params.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-core/bundle/params.ts
@@ -86,7 +86,7 @@ const buildKeyMap = (fields: FieldsConfig, map?: KeyMap): KeyMap => {
 };
 
 interface Params {
-  body: unknown;
+  body?: unknown;
   headers: Record<string, unknown>;
   path: Record<string, unknown>;
   query: Record<string, unknown>;
@@ -94,7 +94,12 @@ interface Params {
 
 const stripEmptySlots = (params: Params) => {
   for (const [slot, value] of Object.entries(params)) {
-    if (value && typeof value === 'object' && !Object.keys(value).length) {
+    if (
+      slot !== 'body' &&
+      value &&
+      typeof value === 'object' &&
+      !Object.keys(value).length
+    ) {
       delete params[slot as Slot];
     }
   }
@@ -105,7 +110,6 @@ export const buildClientParams = (
   fields: FieldsConfig,
 ) => {
   const params: Params = {
-    body: {},
     headers: {},
     path: {},
     query: {},


### PR DESCRIPTION
Fixes #3340

Currently when the body data is an empty array or empty object, the stripEmptySlots method will delete the body from the params, which then causes the POST / PUT to not succeed.  This ensures that the body is never deleted and only gets added to the params of a PUT/POST when it is defined as a parameter.