### PR TITLE
fix: use serializedBody instead of raw body in fetch client SSE handler

### DIFF
--- a/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/client.gen.ts
+++ b/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-valibot/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/transformers/type-format-zod/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/client.gen.ts
@@ -241,7 +241,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
@@ -239,7 +239,7 @@ export const createClient = (config: Config = {}): Client => {
     const { opts, url } = await beforeRequest(options);
     return createSseClient({
       ...opts,
-      body: opts.body as BodyInit | null | undefined,
+      body: opts.serializedBody as BodyInit | null | undefined,
       headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {


### PR DESCRIPTION
The makeSseFn function was passing opts.body (the raw JS object) to createSseClient instead of opts.serializedBody, causing POST SSE endpoints with JSON bodies to send [object Object].