### PR TITLE
fix: pass error type generic to defineQueryOptions in @pinia/colada plugin

### DIFF
--- a/.changeset/dry-waves-play.md
+++ b/.changeset/dry-waves-play.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@pinia/colada)**: fix: pass error type generic to `defineQueryOptions`

--- a/examples/openapi-ts-pinia-colada/src/client/@pinia/colada.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/@pinia/colada.gen.ts
@@ -37,12 +37,19 @@ import type {
   DeletePetData,
   DeleteUserData,
   FindPetsByStatusData,
+  FindPetsByStatusResponse,
   FindPetsByTagsData,
+  FindPetsByTagsResponse,
   GetInventoryData,
+  GetInventoryResponse,
   GetOrderByIdData,
+  GetOrderByIdResponse,
   GetPetByIdData,
+  GetPetByIdResponse,
   GetUserByNameData,
+  GetUserByNameResponse,
   LoginUserData,
+  LoginUserResponse,
   LogoutUserData,
   PlaceOrderData,
   PlaceOrderResponse,
@@ -136,26 +143,32 @@ const createQueryKey = <TOptions extends Options>(
  *
  * Multiple status values can be provided with comma separated strings.
  */
-export const findPetsByStatusQuery = defineQueryOptions(
-  (options: Options<FindPetsByStatusData>) => ({
-    key: createQueryKey('findPetsByStatus', options),
-    query: async (context) => {
-      const { data } = await findPetsByStatus({
-        ...options,
-        ...context,
-        throwOnError: true,
-      });
-      return data;
-    },
-  }),
-);
+export const findPetsByStatusQuery = defineQueryOptions<
+  Options<FindPetsByStatusData>,
+  FindPetsByStatusResponse,
+  Error
+>((options: Options<FindPetsByStatusData>) => ({
+  key: createQueryKey('findPetsByStatus', options),
+  query: async (context) => {
+    const { data } = await findPetsByStatus({
+      ...options,
+      ...context,
+      throwOnError: true,
+    });
+    return data;
+  },
+}));
 
 /**
  * Finds Pets by tags.
  *
  * Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
  */
-export const findPetsByTagsQuery = defineQueryOptions((options: Options<FindPetsByTagsData>) => ({
+export const findPetsByTagsQuery = defineQueryOptions<
+  Options<FindPetsByTagsData>,
+  FindPetsByTagsResponse,
+  Error
+>((options: Options<FindPetsByTagsData>) => ({
   key: createQueryKey('findPetsByTags', options),
   query: async (context) => {
     const { data } = await findPetsByTags({
@@ -190,7 +203,11 @@ export const deletePetMutation = (
  *
  * Returns a single pet.
  */
-export const getPetByIdQuery = defineQueryOptions((options: Options<GetPetByIdData>) => ({
+export const getPetByIdQuery = defineQueryOptions<
+  Options<GetPetByIdData>,
+  GetPetByIdResponse,
+  Error
+>((options: Options<GetPetByIdData>) => ({
   key: createQueryKey('getPetById', options),
   query: async (context) => {
     const { data } = await getPetById({
@@ -243,7 +260,11 @@ export const uploadFileMutation = (
  *
  * Returns a map of status codes to quantities.
  */
-export const getInventoryQuery = defineQueryOptions((options?: Options<GetInventoryData>) => ({
+export const getInventoryQuery = defineQueryOptions<
+  Options<GetInventoryData>,
+  GetInventoryResponse,
+  Error
+>((options?: Options<GetInventoryData>) => ({
   key: createQueryKey('getInventory', options),
   query: async (context) => {
     const { data } = await getInventory({
@@ -296,7 +317,11 @@ export const deleteOrderMutation = (
  *
  * For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
  */
-export const getOrderByIdQuery = defineQueryOptions((options: Options<GetOrderByIdData>) => ({
+export const getOrderByIdQuery = defineQueryOptions<
+  Options<GetOrderByIdData>,
+  GetOrderByIdResponse,
+  Error
+>((options: Options<GetOrderByIdData>) => ({
   key: createQueryKey('getOrderById', options),
   query: async (context) => {
     const { data } = await getOrderById({
@@ -353,34 +378,38 @@ export const createUsersWithListInputMutation = (
  *
  * Log into the system.
  */
-export const loginUserQuery = defineQueryOptions((options?: Options<LoginUserData>) => ({
-  key: createQueryKey('loginUser', options),
-  query: async (context) => {
-    const { data } = await loginUser({
-      ...options,
-      ...context,
-      throwOnError: true,
-    });
-    return data;
-  },
-}));
+export const loginUserQuery = defineQueryOptions<Options<LoginUserData>, LoginUserResponse, Error>(
+  (options?: Options<LoginUserData>) => ({
+    key: createQueryKey('loginUser', options),
+    query: async (context) => {
+      const { data } = await loginUser({
+        ...options,
+        ...context,
+        throwOnError: true,
+      });
+      return data;
+    },
+  }),
+);
 
 /**
  * Logs out current logged in user session.
  *
  * Log user out of the system.
  */
-export const logoutUserQuery = defineQueryOptions((options?: Options<LogoutUserData>) => ({
-  key: createQueryKey('logoutUser', options),
-  query: async (context) => {
-    const { data } = await logoutUser({
-      ...options,
-      ...context,
-      throwOnError: true,
-    });
-    return data;
-  },
-}));
+export const logoutUserQuery = defineQueryOptions<Options<LogoutUserData>, unknown, Error>(
+  (options?: Options<LogoutUserData>) => ({
+    key: createQueryKey('logoutUser', options),
+    query: async (context) => {
+      const { data } = await logoutUser({
+        ...options,
+        ...context,
+        throwOnError: true,
+      });
+      return data;
+    },
+  }),
+);
 
 /**
  * Delete user resource.
@@ -405,7 +434,11 @@ export const deleteUserMutation = (
  *
  * Get user detail based on username.
  */
-export const getUserByNameQuery = defineQueryOptions((options: Options<GetUserByNameData>) => ({
+export const getUserByNameQuery = defineQueryOptions<
+  Options<GetUserByNameData>,
+  GetUserByNameResponse,
+  Error
+>((options: Options<GetUserByNameData>) => ({
   key: createQueryKey('getUserByName', options),
   query: async (context) => {
     const { data } = await getUserByName({

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/@pinia/colada.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/@pinia/colada.gen.ts
@@ -5,7 +5,7 @@ import { type _JSONValue, defineQueryOptions, type UseMutationOptions } from '@p
 import { serializeQueryKeyValue } from '../client';
 import { client } from '../client.gen';
 import { BarBazService, BarService, FooBazService, FooService, type Options } from '../sdk.gen';
-import type { FooBarPostData, FooBarPostResponse, FooBarPutData, FooBarPutResponse, FooPostData, FooPostResponse, FooPutData, FooPutResponse, GetFooBarData, GetFooData } from '../types.gen';
+import type { FooBarPostData, FooBarPostResponse, FooBarPutData, FooBarPutResponse, FooPostData, FooPostResponse, FooPutData, FooPutResponse, GetFooBarData, GetFooBarResponse, GetFooData, GetFooResponse } from '../types.gen';
 
 export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'path'> & {
@@ -44,7 +44,7 @@ const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions
 
 export const getFooQueryKey = (options?: Options<GetFooData>) => createQueryKey('getFoo', options);
 
-export const getFooQuery = defineQueryOptions((options?: Options<GetFooData>) => ({
+export const getFooQuery = defineQueryOptions<Options<GetFooData>, GetFooResponse, Error>((options?: Options<GetFooData>) => ({
     key: getFooQueryKey(options),
     query: async (context) => {
         const { data } = await FooBazService.getFoo({
@@ -80,7 +80,7 @@ export const fooPutMutation = (options?: Partial<Options<FooPutData>>): UseMutat
 
 export const getFooBarQueryKey = (options?: Options<GetFooBarData>) => createQueryKey('getFooBar', options);
 
-export const getFooBarQuery = defineQueryOptions((options?: Options<GetFooBarData>) => ({
+export const getFooBarQuery = defineQueryOptions<Options<GetFooBarData>, GetFooBarResponse, Error>((options?: Options<GetFooBarData>) => ({
     key: getFooBarQueryKey(options),
     query: async (context) => {
         const { data } = await BarBazService.getFooBar({

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/@pinia/colada.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/@pinia/colada.gen.ts
@@ -5,7 +5,7 @@ import { type _JSONValue, defineQueryOptions, type UseMutationOptions } from '@p
 import { serializeQueryKeyValue } from '../client';
 import { client } from '../client.gen';
 import { callToTestOrderOfParams, callWithDefaultOptionalParameters, callWithDefaultParameters, callWithDescriptions, callWithDuplicateResponses, callWithNoContentResponse, callWithParameters, callWithResponse, callWithResponseAndNoContentResponse, callWithResponses, callWithResultFromHeader, callWithWeirdParameterNames, collectionFormat, complexTypes, deleteCallWithoutParametersAndResponse, dummyA, dummyB, duplicateName, duplicateName2, duplicateName3, duplicateName4, fooWow, getCallWithoutParametersAndResponse, nonAsciiæøåÆøÅöôêÊ字符串, type Options, patchApiVbyApiVersionNoTag, patchCallWithoutParametersAndResponse, postApiVbyApiVersionBody, postCallWithoutParametersAndResponse, putCallWithoutParametersAndResponse, serviceWithEmptyTag, testErrorCode, types } from '../sdk.gen';
-import type { CallToTestOrderOfParamsData, CallWithDefaultOptionalParametersData, CallWithDefaultParametersData, CallWithDescriptionsData, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithDuplicateResponsesResponse, CallWithNoContentResponseData, CallWithParametersData, CallWithResponseAndNoContentResponseData, CallWithResponseData, CallWithResponsesData, CallWithResponsesError, CallWithResponsesResponse, CallWithResultFromHeaderData, CallWithWeirdParameterNamesData, CollectionFormatData, ComplexTypesData, DeleteCallWithoutParametersAndResponseData, DummyAData, DummyBData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, DuplicateNameData, FooWowData, GetCallWithoutParametersAndResponseData, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, PatchApiVbyApiVersionNoTagData, PatchCallWithoutParametersAndResponseData, PostApiVbyApiVersionBodyData, PostApiVbyApiVersionBodyError, PostApiVbyApiVersionBodyResponse, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, ServiceWithEmptyTagData, TestErrorCodeData, TypesData } from '../types.gen';
+import type { CallToTestOrderOfParamsData, CallWithDefaultOptionalParametersData, CallWithDefaultParametersData, CallWithDescriptionsData, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithDuplicateResponsesResponse, CallWithNoContentResponseData, CallWithParametersData, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, CallWithResponseData, CallWithResponseResponse, CallWithResponsesData, CallWithResponsesError, CallWithResponsesResponse, CallWithResultFromHeaderData, CallWithWeirdParameterNamesData, CollectionFormatData, ComplexTypesData, ComplexTypesResponse, DeleteCallWithoutParametersAndResponseData, DummyAData, DummyBData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, DuplicateNameData, FooWowData, GetCallWithoutParametersAndResponseData, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, PatchApiVbyApiVersionNoTagData, PatchCallWithoutParametersAndResponseData, PostApiVbyApiVersionBodyData, PostApiVbyApiVersionBodyError, PostApiVbyApiVersionBodyResponse, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, ServiceWithEmptyTagData, TestErrorCodeData, TypesData, TypesResponse } from '../types.gen';
 
 export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'path'> & {
@@ -44,7 +44,7 @@ const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions
 
 export const serviceWithEmptyTagQueryKey = (options?: Options<ServiceWithEmptyTagData>) => createQueryKey('serviceWithEmptyTag', options);
 
-export const serviceWithEmptyTagQuery = defineQueryOptions((options?: Options<ServiceWithEmptyTagData>) => ({
+export const serviceWithEmptyTagQuery = defineQueryOptions<Options<ServiceWithEmptyTagData>, unknown, Error>((options?: Options<ServiceWithEmptyTagData>) => ({
     key: serviceWithEmptyTagQueryKey(options),
     query: async (context) => {
         const { data } = await serviceWithEmptyTag({
@@ -91,7 +91,7 @@ export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial
 
 export const getCallWithoutParametersAndResponseQueryKey = (options?: Options<GetCallWithoutParametersAndResponseData>) => createQueryKey('getCallWithoutParametersAndResponse', options);
 
-export const getCallWithoutParametersAndResponseQuery = defineQueryOptions((options?: Options<GetCallWithoutParametersAndResponseData>) => ({
+export const getCallWithoutParametersAndResponseQuery = defineQueryOptions<Options<GetCallWithoutParametersAndResponseData>, unknown, Error>((options?: Options<GetCallWithoutParametersAndResponseData>) => ({
     key: getCallWithoutParametersAndResponseQueryKey(options),
     query: async (context) => {
         const { data } = await getCallWithoutParametersAndResponse({
@@ -171,7 +171,7 @@ export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<Ca
 
 export const callWithDefaultParametersQueryKey = (options: Options<CallWithDefaultParametersData>) => createQueryKey('callWithDefaultParameters', options);
 
-export const callWithDefaultParametersQuery = defineQueryOptions((options: Options<CallWithDefaultParametersData>) => ({
+export const callWithDefaultParametersQuery = defineQueryOptions<Options<CallWithDefaultParametersData>, unknown, Error>((options: Options<CallWithDefaultParametersData>) => ({
     key: callWithDefaultParametersQueryKey(options),
     query: async (context) => {
         const { data } = await callWithDefaultParameters({
@@ -218,7 +218,7 @@ export const duplicateNameMutation = (options?: Partial<Options<DuplicateNameDat
 
 export const duplicateName2QueryKey = (options?: Options<DuplicateName2Data>) => createQueryKey('duplicateName2', options);
 
-export const duplicateName2Query = defineQueryOptions((options?: Options<DuplicateName2Data>) => ({
+export const duplicateName2Query = defineQueryOptions<Options<DuplicateName2Data>, unknown, Error>((options?: Options<DuplicateName2Data>) => ({
     key: duplicateName2QueryKey(options),
     query: async (context) => {
         const { data } = await duplicateName2({
@@ -254,7 +254,7 @@ export const duplicateName4Mutation = (options?: Partial<Options<DuplicateName4D
 
 export const callWithNoContentResponseQueryKey = (options?: Options<CallWithNoContentResponseData>) => createQueryKey('callWithNoContentResponse', options);
 
-export const callWithNoContentResponseQuery = defineQueryOptions((options?: Options<CallWithNoContentResponseData>) => ({
+export const callWithNoContentResponseQuery = defineQueryOptions<Options<CallWithNoContentResponseData>, unknown, Error>((options?: Options<CallWithNoContentResponseData>) => ({
     key: callWithNoContentResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithNoContentResponse({
@@ -268,7 +268,7 @@ export const callWithNoContentResponseQuery = defineQueryOptions((options?: Opti
 
 export const callWithResponseAndNoContentResponseQueryKey = (options?: Options<CallWithResponseAndNoContentResponseData>) => createQueryKey('callWithResponseAndNoContentResponse', options);
 
-export const callWithResponseAndNoContentResponseQuery = defineQueryOptions((options?: Options<CallWithResponseAndNoContentResponseData>) => ({
+export const callWithResponseAndNoContentResponseQuery = defineQueryOptions<Options<CallWithResponseAndNoContentResponseData>, CallWithResponseAndNoContentResponseResponse, Error>((options?: Options<CallWithResponseAndNoContentResponseData>) => ({
     key: callWithResponseAndNoContentResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithResponseAndNoContentResponse({
@@ -282,7 +282,7 @@ export const callWithResponseAndNoContentResponseQuery = defineQueryOptions((opt
 
 export const dummyAQueryKey = (options?: Options<DummyAData>) => createQueryKey('dummyA', options);
 
-export const dummyAQuery = defineQueryOptions((options?: Options<DummyAData>) => ({
+export const dummyAQuery = defineQueryOptions<Options<DummyAData>, unknown, Error>((options?: Options<DummyAData>) => ({
     key: dummyAQueryKey(options),
     query: async (context) => {
         const { data } = await dummyA({
@@ -296,7 +296,7 @@ export const dummyAQuery = defineQueryOptions((options?: Options<DummyAData>) =>
 
 export const dummyBQueryKey = (options?: Options<DummyBData>) => createQueryKey('dummyB', options);
 
-export const dummyBQuery = defineQueryOptions((options?: Options<DummyBData>) => ({
+export const dummyBQuery = defineQueryOptions<Options<DummyBData>, unknown, Error>((options?: Options<DummyBData>) => ({
     key: dummyBQueryKey(options),
     query: async (context) => {
         const { data } = await dummyB({
@@ -310,7 +310,7 @@ export const dummyBQuery = defineQueryOptions((options?: Options<DummyBData>) =>
 
 export const callWithResponseQueryKey = (options?: Options<CallWithResponseData>) => createQueryKey('callWithResponse', options);
 
-export const callWithResponseQuery = defineQueryOptions((options?: Options<CallWithResponseData>) => ({
+export const callWithResponseQuery = defineQueryOptions<Options<CallWithResponseData>, CallWithResponseResponse, Error>((options?: Options<CallWithResponseData>) => ({
     key: callWithResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithResponse({
@@ -346,7 +346,7 @@ export const callWithResponsesMutation = (options?: Partial<Options<CallWithResp
 
 export const collectionFormatQueryKey = (options: Options<CollectionFormatData>) => createQueryKey('collectionFormat', options);
 
-export const collectionFormatQuery = defineQueryOptions((options: Options<CollectionFormatData>) => ({
+export const collectionFormatQuery = defineQueryOptions<Options<CollectionFormatData>, unknown, Error>((options: Options<CollectionFormatData>) => ({
     key: collectionFormatQueryKey(options),
     query: async (context) => {
         const { data } = await collectionFormat({
@@ -360,7 +360,7 @@ export const collectionFormatQuery = defineQueryOptions((options: Options<Collec
 
 export const typesQueryKey = (options: Options<TypesData>) => createQueryKey('types', options);
 
-export const typesQuery = defineQueryOptions((options: Options<TypesData>) => ({
+export const typesQuery = defineQueryOptions<Options<TypesData>, TypesResponse, Error>((options: Options<TypesData>) => ({
     key: typesQueryKey(options),
     query: async (context) => {
         const { data } = await types({
@@ -374,7 +374,7 @@ export const typesQuery = defineQueryOptions((options: Options<TypesData>) => ({
 
 export const complexTypesQueryKey = (options: Options<ComplexTypesData>) => createQueryKey('complexTypes', options);
 
-export const complexTypesQuery = defineQueryOptions((options: Options<ComplexTypesData>) => ({
+export const complexTypesQuery = defineQueryOptions<Options<ComplexTypesData>, ComplexTypesResponse, Error>((options: Options<ComplexTypesData>) => ({
     key: complexTypesQueryKey(options),
     query: async (context) => {
         const { data } = await complexTypes({

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/@pinia/colada.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/@pinia/colada.gen.ts
@@ -5,7 +5,7 @@ import { type _JSONValue, defineQueryOptions, type UseMutationOptions } from '@p
 import { serializeQueryKeyValue } from '../client';
 import { client } from '../client.gen';
 import { BarBazService, BarService, FooBazService, FooService, type Options } from '../sdk.gen';
-import type { FooBarPostData, FooBarPostResponse, FooBarPutData, FooBarPutResponse, FooPostData, FooPostResponse, FooPutData, FooPutResponse, GetFooBarData, GetFooData } from '../types.gen';
+import type { FooBarPostData, FooBarPostResponse, FooBarPutData, FooBarPutResponse, FooPostData, FooPostResponse, FooPutData, FooPutResponse, GetFooBarData, GetFooBarResponse, GetFooData, GetFooResponse } from '../types.gen';
 
 export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'path'> & {
@@ -44,7 +44,7 @@ const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions
 
 export const getFooQueryKey = (options?: Options<GetFooData>) => createQueryKey('getFoo', options);
 
-export const getFooQuery = defineQueryOptions((options?: Options<GetFooData>) => ({
+export const getFooQuery = defineQueryOptions<Options<GetFooData>, GetFooResponse, Error>((options?: Options<GetFooData>) => ({
     key: getFooQueryKey(options),
     query: async (context) => {
         const { data } = await FooBazService.getFoo({
@@ -80,7 +80,7 @@ export const fooPutMutation = (options?: Partial<Options<FooPutData>>): UseMutat
 
 export const getFooBarQueryKey = (options?: Options<GetFooBarData>) => createQueryKey('getFooBar', options);
 
-export const getFooBarQuery = defineQueryOptions((options?: Options<GetFooBarData>) => ({
+export const getFooBarQuery = defineQueryOptions<Options<GetFooBarData>, GetFooBarResponse, Error>((options?: Options<GetFooBarData>) => ({
     key: getFooBarQueryKey(options),
     query: async (context) => {
         const { data } = await BarBazService.getFooBar({

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/@pinia/colada.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/@pinia/colada.gen.ts
@@ -5,7 +5,7 @@ import { type _JSONValue, defineQueryOptions, type UseMutationOptions } from '@p
 import { serializeQueryKeyValue } from '../client';
 import { client } from '../client.gen';
 import { apiVVersionODataControllerCount, callToTestOrderOfParams, callWithDefaultOptionalParameters, callWithDefaultParameters, callWithDescriptions, callWithDuplicateResponses, callWithNoContentResponse, callWithParameters, callWithResponse, callWithResponseAndNoContentResponse, callWithResponses, callWithResultFromHeader, callWithWeirdParameterNames, collectionFormat, complexParams, complexTypes, deleteCallWithoutParametersAndResponse, deleteFoo, deprecatedCall, dummyA, dummyB, duplicateName, duplicateName2, duplicateName3, duplicateName4, export_, fileResponse, fooWow, getApiVbyApiVersionSimpleOperation, getCallWithOptionalParam, getCallWithoutParametersAndResponse, import_, multipartRequest, multipartResponse, nonAsciiæøåÆøÅöôêÊ字符串, type Options, patchApiVbyApiVersionNoTag, patchCallWithoutParametersAndResponse, postApiVbyApiVersionFormData, postApiVbyApiVersionRequestBody, postCallWithOptionalParam, postCallWithoutParametersAndResponse, putCallWithoutParametersAndResponse, putWithFormUrlEncoded, testErrorCode, types, uploadFile } from '../sdk.gen';
-import type { ApiVVersionODataControllerCountData, CallToTestOrderOfParamsData, CallWithDefaultOptionalParametersData, CallWithDefaultParametersData, CallWithDescriptionsData, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithDuplicateResponsesResponse, CallWithNoContentResponseData, CallWithParametersData, CallWithResponseAndNoContentResponseData, CallWithResponseData, CallWithResponsesData, CallWithResponsesError, CallWithResponsesResponse, CallWithResultFromHeaderData, CallWithWeirdParameterNamesData, CollectionFormatData, ComplexParamsData, ComplexParamsResponse, ComplexTypesData, DeleteCallWithoutParametersAndResponseData, DeleteFooData3, DeprecatedCallData, DummyAData, DummyBData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, DuplicateNameData, ExportData, FileResponseData, FooWowData, GetApiVbyApiVersionSimpleOperationData, GetCallWithOptionalParamData, GetCallWithoutParametersAndResponseData, ImportData, ImportResponse, MultipartRequestData, MultipartResponseData, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, PatchApiVbyApiVersionNoTagData, PatchCallWithoutParametersAndResponseData, PostApiVbyApiVersionFormDataData, PostApiVbyApiVersionRequestBodyData, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, PutWithFormUrlEncodedData, TestErrorCodeData, TypesData, UploadFileData, UploadFileResponse } from '../types.gen';
+import type { ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, CallToTestOrderOfParamsData, CallWithDefaultOptionalParametersData, CallWithDefaultParametersData, CallWithDescriptionsData, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithDuplicateResponsesResponse, CallWithNoContentResponseData, CallWithNoContentResponseResponse, CallWithParametersData, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, CallWithResponseData, CallWithResponseResponse, CallWithResponsesData, CallWithResponsesError, CallWithResponsesResponse, CallWithResultFromHeaderData, CallWithWeirdParameterNamesData, CollectionFormatData, ComplexParamsData, ComplexParamsResponse, ComplexTypesData, ComplexTypesResponse, DeleteCallWithoutParametersAndResponseData, DeleteFooData3, DeprecatedCallData, DummyAData, DummyAResponse, DummyBData, DummyBResponse, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, DuplicateNameData, ExportData, FileResponseData, FileResponseResponse, FooWowData, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationError, GetApiVbyApiVersionSimpleOperationResponse, GetCallWithOptionalParamData, GetCallWithoutParametersAndResponseData, ImportData, ImportResponse, MultipartRequestData, MultipartResponseData, MultipartResponseResponse, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, PatchApiVbyApiVersionNoTagData, PatchCallWithoutParametersAndResponseData, PostApiVbyApiVersionFormDataData, PostApiVbyApiVersionRequestBodyData, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, PutWithFormUrlEncodedData, TestErrorCodeData, TypesData, TypesResponse, UploadFileData, UploadFileResponse } from '../types.gen';
 
 export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'path'> & {
@@ -44,7 +44,7 @@ const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions
 
 export const exportQueryKey = (options?: Options<ExportData>) => createQueryKey('export', options);
 
-export const exportQuery = defineQueryOptions((options?: Options<ExportData>) => ({
+export const exportQuery = defineQueryOptions<Options<ExportData>, unknown, Error>((options?: Options<ExportData>) => ({
     key: exportQueryKey(options),
     query: async (context) => {
         const { data } = await export_({
@@ -91,7 +91,7 @@ export const fooWowMutation = (options?: Partial<Options<FooWowData>>): UseMutat
 
 export const apiVVersionODataControllerCountQueryKey = (options?: Options<ApiVVersionODataControllerCountData>) => createQueryKey('apiVVersionODataControllerCount', options);
 
-export const apiVVersionODataControllerCountQuery = defineQueryOptions((options?: Options<ApiVVersionODataControllerCountData>) => ({
+export const apiVVersionODataControllerCountQuery = defineQueryOptions<Options<ApiVVersionODataControllerCountData>, ApiVVersionODataControllerCountResponse, Error>((options?: Options<ApiVVersionODataControllerCountData>) => ({
     key: apiVVersionODataControllerCountQueryKey(options),
     query: async (context) => {
         const { data } = await apiVVersionODataControllerCount({
@@ -105,7 +105,7 @@ export const apiVVersionODataControllerCountQuery = defineQueryOptions((options?
 
 export const getApiVbyApiVersionSimpleOperationQueryKey = (options: Options<GetApiVbyApiVersionSimpleOperationData>) => createQueryKey('getApiVbyApiVersionSimpleOperation', options);
 
-export const getApiVbyApiVersionSimpleOperationQuery = defineQueryOptions((options: Options<GetApiVbyApiVersionSimpleOperationData>) => ({
+export const getApiVbyApiVersionSimpleOperationQuery = defineQueryOptions<Options<GetApiVbyApiVersionSimpleOperationData>, GetApiVbyApiVersionSimpleOperationResponse, GetApiVbyApiVersionSimpleOperationError>((options: Options<GetApiVbyApiVersionSimpleOperationData>) => ({
     key: getApiVbyApiVersionSimpleOperationQueryKey(options),
     query: async (context) => {
         const { data } = await getApiVbyApiVersionSimpleOperation({
@@ -130,7 +130,7 @@ export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial
 
 export const getCallWithoutParametersAndResponseQueryKey = (options?: Options<GetCallWithoutParametersAndResponseData>) => createQueryKey('getCallWithoutParametersAndResponse', options);
 
-export const getCallWithoutParametersAndResponseQuery = defineQueryOptions((options?: Options<GetCallWithoutParametersAndResponseData>) => ({
+export const getCallWithoutParametersAndResponseQuery = defineQueryOptions<Options<GetCallWithoutParametersAndResponseData>, unknown, Error>((options?: Options<GetCallWithoutParametersAndResponseData>) => ({
     key: getCallWithoutParametersAndResponseQueryKey(options),
     query: async (context) => {
         const { data } = await getCallWithoutParametersAndResponse({
@@ -235,7 +235,7 @@ export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<Ca
 
 export const getCallWithOptionalParamQueryKey = (options: Options<GetCallWithOptionalParamData>) => createQueryKey('getCallWithOptionalParam', options);
 
-export const getCallWithOptionalParamQuery = defineQueryOptions((options: Options<GetCallWithOptionalParamData>) => ({
+export const getCallWithOptionalParamQuery = defineQueryOptions<Options<GetCallWithOptionalParamData>, unknown, Error>((options: Options<GetCallWithOptionalParamData>) => ({
     key: getCallWithOptionalParamQueryKey(options),
     query: async (context) => {
         const { data } = await getCallWithOptionalParam({
@@ -282,7 +282,7 @@ export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<P
 
 export const callWithDefaultParametersQueryKey = (options?: Options<CallWithDefaultParametersData>) => createQueryKey('callWithDefaultParameters', options);
 
-export const callWithDefaultParametersQuery = defineQueryOptions((options?: Options<CallWithDefaultParametersData>) => ({
+export const callWithDefaultParametersQuery = defineQueryOptions<Options<CallWithDefaultParametersData>, unknown, Error>((options?: Options<CallWithDefaultParametersData>) => ({
     key: callWithDefaultParametersQueryKey(options),
     query: async (context) => {
         const { data } = await callWithDefaultParameters({
@@ -329,7 +329,7 @@ export const duplicateNameMutation = (options?: Partial<Options<DuplicateNameDat
 
 export const duplicateName2QueryKey = (options?: Options<DuplicateName2Data>) => createQueryKey('duplicateName2', options);
 
-export const duplicateName2Query = defineQueryOptions((options?: Options<DuplicateName2Data>) => ({
+export const duplicateName2Query = defineQueryOptions<Options<DuplicateName2Data>, unknown, Error>((options?: Options<DuplicateName2Data>) => ({
     key: duplicateName2QueryKey(options),
     query: async (context) => {
         const { data } = await duplicateName2({
@@ -365,7 +365,7 @@ export const duplicateName4Mutation = (options?: Partial<Options<DuplicateName4D
 
 export const callWithNoContentResponseQueryKey = (options?: Options<CallWithNoContentResponseData>) => createQueryKey('callWithNoContentResponse', options);
 
-export const callWithNoContentResponseQuery = defineQueryOptions((options?: Options<CallWithNoContentResponseData>) => ({
+export const callWithNoContentResponseQuery = defineQueryOptions<Options<CallWithNoContentResponseData>, CallWithNoContentResponseResponse, Error>((options?: Options<CallWithNoContentResponseData>) => ({
     key: callWithNoContentResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithNoContentResponse({
@@ -379,7 +379,7 @@ export const callWithNoContentResponseQuery = defineQueryOptions((options?: Opti
 
 export const callWithResponseAndNoContentResponseQueryKey = (options?: Options<CallWithResponseAndNoContentResponseData>) => createQueryKey('callWithResponseAndNoContentResponse', options);
 
-export const callWithResponseAndNoContentResponseQuery = defineQueryOptions((options?: Options<CallWithResponseAndNoContentResponseData>) => ({
+export const callWithResponseAndNoContentResponseQuery = defineQueryOptions<Options<CallWithResponseAndNoContentResponseData>, CallWithResponseAndNoContentResponseResponse, Error>((options?: Options<CallWithResponseAndNoContentResponseData>) => ({
     key: callWithResponseAndNoContentResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithResponseAndNoContentResponse({
@@ -393,7 +393,7 @@ export const callWithResponseAndNoContentResponseQuery = defineQueryOptions((opt
 
 export const dummyAQueryKey = (options?: Options<DummyAData>) => createQueryKey('dummyA', options);
 
-export const dummyAQuery = defineQueryOptions((options?: Options<DummyAData>) => ({
+export const dummyAQuery = defineQueryOptions<Options<DummyAData>, DummyAResponse, Error>((options?: Options<DummyAData>) => ({
     key: dummyAQueryKey(options),
     query: async (context) => {
         const { data } = await dummyA({
@@ -407,7 +407,7 @@ export const dummyAQuery = defineQueryOptions((options?: Options<DummyAData>) =>
 
 export const dummyBQueryKey = (options?: Options<DummyBData>) => createQueryKey('dummyB', options);
 
-export const dummyBQuery = defineQueryOptions((options?: Options<DummyBData>) => ({
+export const dummyBQuery = defineQueryOptions<Options<DummyBData>, DummyBResponse, Error>((options?: Options<DummyBData>) => ({
     key: dummyBQueryKey(options),
     query: async (context) => {
         const { data } = await dummyB({
@@ -421,7 +421,7 @@ export const dummyBQuery = defineQueryOptions((options?: Options<DummyBData>) =>
 
 export const callWithResponseQueryKey = (options?: Options<CallWithResponseData>) => createQueryKey('callWithResponse', options);
 
-export const callWithResponseQuery = defineQueryOptions((options?: Options<CallWithResponseData>) => ({
+export const callWithResponseQuery = defineQueryOptions<Options<CallWithResponseData>, CallWithResponseResponse, Error>((options?: Options<CallWithResponseData>) => ({
     key: callWithResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithResponse({
@@ -457,7 +457,7 @@ export const callWithResponsesMutation = (options?: Partial<Options<CallWithResp
 
 export const collectionFormatQueryKey = (options: Options<CollectionFormatData>) => createQueryKey('collectionFormat', options);
 
-export const collectionFormatQuery = defineQueryOptions((options: Options<CollectionFormatData>) => ({
+export const collectionFormatQuery = defineQueryOptions<Options<CollectionFormatData>, unknown, Error>((options: Options<CollectionFormatData>) => ({
     key: collectionFormatQueryKey(options),
     query: async (context) => {
         const { data } = await collectionFormat({
@@ -471,7 +471,7 @@ export const collectionFormatQuery = defineQueryOptions((options: Options<Collec
 
 export const typesQueryKey = (options: Options<TypesData>) => createQueryKey('types', options);
 
-export const typesQuery = defineQueryOptions((options: Options<TypesData>) => ({
+export const typesQuery = defineQueryOptions<Options<TypesData>, TypesResponse, Error>((options: Options<TypesData>) => ({
     key: typesQueryKey(options),
     query: async (context) => {
         const { data } = await types({
@@ -496,7 +496,7 @@ export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>): 
 
 export const fileResponseQueryKey = (options: Options<FileResponseData>) => createQueryKey('fileResponse', options);
 
-export const fileResponseQuery = defineQueryOptions((options: Options<FileResponseData>) => ({
+export const fileResponseQuery = defineQueryOptions<Options<FileResponseData>, FileResponseResponse, Error>((options: Options<FileResponseData>) => ({
     key: fileResponseQueryKey(options),
     query: async (context) => {
         const { data } = await fileResponse({
@@ -510,7 +510,7 @@ export const fileResponseQuery = defineQueryOptions((options: Options<FileRespon
 
 export const complexTypesQueryKey = (options: Options<ComplexTypesData>) => createQueryKey('complexTypes', options);
 
-export const complexTypesQuery = defineQueryOptions((options: Options<ComplexTypesData>) => ({
+export const complexTypesQuery = defineQueryOptions<Options<ComplexTypesData>, ComplexTypesResponse, Error>((options: Options<ComplexTypesData>) => ({
     key: complexTypesQueryKey(options),
     query: async (context) => {
         const { data } = await complexTypes({
@@ -524,7 +524,7 @@ export const complexTypesQuery = defineQueryOptions((options: Options<ComplexTyp
 
 export const multipartResponseQueryKey = (options?: Options<MultipartResponseData>) => createQueryKey('multipartResponse', options);
 
-export const multipartResponseQuery = defineQueryOptions((options?: Options<MultipartResponseData>) => ({
+export const multipartResponseQuery = defineQueryOptions<Options<MultipartResponseData>, MultipartResponseResponse, Error>((options?: Options<MultipartResponseData>) => ({
     key: multipartResponseQueryKey(options),
     query: async (context) => {
         const { data } = await multipartResponse({

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/@pinia/colada.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/@pinia/colada.gen.ts
@@ -5,7 +5,7 @@ import { type _JSONValue, defineQueryOptions, type UseMutationOptions } from '@p
 import { serializeQueryKeyValue } from '../client';
 import { client } from '../client.gen';
 import { BarBazService, BarService, FooBazService, FooService, type Options } from '../sdk.gen';
-import type { FooBarPostData, FooBarPostResponse, FooBarPutData, FooBarPutResponse, FooPostData, FooPostResponse, FooPutData, FooPutResponse, GetFooBarData, GetFooData } from '../types.gen';
+import type { FooBarPostData, FooBarPostResponse, FooBarPutData, FooBarPutResponse, FooPostData, FooPostResponse, FooPutData, FooPutResponse, GetFooBarData, GetFooBarResponse, GetFooData, GetFooResponse } from '../types.gen';
 
 export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'path'> & {
@@ -44,7 +44,7 @@ const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions
 
 export const getFooQueryKey = (options?: Options<GetFooData>) => createQueryKey('getFoo', options);
 
-export const getFooQuery = defineQueryOptions((options?: Options<GetFooData>) => ({
+export const getFooQuery = defineQueryOptions<Options<GetFooData>, GetFooResponse, Error>((options?: Options<GetFooData>) => ({
     key: getFooQueryKey(options),
     query: async (context) => {
         const { data } = await FooBazService.getFoo({
@@ -80,7 +80,7 @@ export const fooPutMutation = (options?: Partial<Options<FooPutData>>): UseMutat
 
 export const getFooBarQueryKey = (options?: Options<GetFooBarData>) => createQueryKey('getFooBar', options);
 
-export const getFooBarQuery = defineQueryOptions((options?: Options<GetFooBarData>) => ({
+export const getFooBarQuery = defineQueryOptions<Options<GetFooBarData>, GetFooBarResponse, Error>((options?: Options<GetFooBarData>) => ({
     key: getFooBarQueryKey(options),
     query: async (context) => {
         const { data } = await BarBazService.getFooBar({

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/@pinia/colada.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/@pinia/colada.gen.ts
@@ -5,7 +5,7 @@ import { type _JSONValue, defineQueryOptions, type UseMutationOptions } from '@p
 import { serializeQueryKeyValue } from '../client';
 import { client } from '../client.gen';
 import { apiVVersionODataControllerCount, callToTestOrderOfParams, callWithDefaultOptionalParameters, callWithDefaultParameters, callWithDescriptions, callWithDuplicateResponses, callWithNoContentResponse, callWithParameters, callWithResponse, callWithResponseAndNoContentResponse, callWithResponses, callWithResultFromHeader, callWithWeirdParameterNames, collectionFormat, complexParams, complexTypes, deleteCallWithoutParametersAndResponse, deleteFoo, deprecatedCall, dummyA, dummyB, duplicateName, duplicateName2, duplicateName3, duplicateName4, export_, fileResponse, fooWow, getApiVbyApiVersionSimpleOperation, getCallWithOptionalParam, getCallWithoutParametersAndResponse, import_, multipartRequest, multipartResponse, nonAsciiæøåÆøÅöôêÊ字符串, type Options, patchApiVbyApiVersionNoTag, patchCallWithoutParametersAndResponse, postApiVbyApiVersionFormData, postApiVbyApiVersionRequestBody, postCallWithOptionalParam, postCallWithoutParametersAndResponse, putCallWithoutParametersAndResponse, putWithFormUrlEncoded, testErrorCode, types, uploadFile } from '../sdk.gen';
-import type { ApiVVersionODataControllerCountData, CallToTestOrderOfParamsData, CallWithDefaultOptionalParametersData, CallWithDefaultParametersData, CallWithDescriptionsData, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithDuplicateResponsesResponse, CallWithNoContentResponseData, CallWithParametersData, CallWithResponseAndNoContentResponseData, CallWithResponseData, CallWithResponsesData, CallWithResponsesError, CallWithResponsesResponse, CallWithResultFromHeaderData, CallWithWeirdParameterNamesData, CollectionFormatData, ComplexParamsData, ComplexParamsResponse, ComplexTypesData, DeleteCallWithoutParametersAndResponseData, DeleteFooData3, DeprecatedCallData, DummyAData, DummyBData, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, DuplicateNameData, ExportData, FileResponseData, FooWowData, GetApiVbyApiVersionSimpleOperationData, GetCallWithOptionalParamData, GetCallWithoutParametersAndResponseData, ImportData, ImportResponse, MultipartRequestData, MultipartResponseData, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, PatchApiVbyApiVersionNoTagData, PatchCallWithoutParametersAndResponseData, PostApiVbyApiVersionFormDataData, PostApiVbyApiVersionRequestBodyData, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, PutWithFormUrlEncodedData, TestErrorCodeData, TypesData, UploadFileData, UploadFileResponse } from '../types.gen';
+import type { ApiVVersionODataControllerCountData, ApiVVersionODataControllerCountResponse, CallToTestOrderOfParamsData, CallWithDefaultOptionalParametersData, CallWithDefaultParametersData, CallWithDescriptionsData, CallWithDuplicateResponsesData, CallWithDuplicateResponsesError, CallWithDuplicateResponsesResponse, CallWithNoContentResponseData, CallWithNoContentResponseResponse, CallWithParametersData, CallWithResponseAndNoContentResponseData, CallWithResponseAndNoContentResponseResponse, CallWithResponseData, CallWithResponseResponse, CallWithResponsesData, CallWithResponsesError, CallWithResponsesResponse, CallWithResultFromHeaderData, CallWithWeirdParameterNamesData, CollectionFormatData, ComplexParamsData, ComplexParamsResponse, ComplexTypesData, ComplexTypesResponse, DeleteCallWithoutParametersAndResponseData, DeleteFooData3, DeprecatedCallData, DummyAData, DummyAResponse, DummyBData, DummyBResponse, DuplicateName2Data, DuplicateName3Data, DuplicateName4Data, DuplicateNameData, ExportData, FileResponseData, FileResponseResponse, FooWowData, GetApiVbyApiVersionSimpleOperationData, GetApiVbyApiVersionSimpleOperationError, GetApiVbyApiVersionSimpleOperationResponse, GetCallWithOptionalParamData, GetCallWithoutParametersAndResponseData, ImportData, ImportResponse, MultipartRequestData, MultipartResponseData, MultipartResponseResponse, NonAsciiæøåÆøÅöôêÊ字符串Data, NonAsciiæøåÆøÅöôêÊ字符串Response, PatchApiVbyApiVersionNoTagData, PatchCallWithoutParametersAndResponseData, PostApiVbyApiVersionFormDataData, PostApiVbyApiVersionRequestBodyData, PostCallWithOptionalParamData, PostCallWithOptionalParamResponse, PostCallWithoutParametersAndResponseData, PutCallWithoutParametersAndResponseData, PutWithFormUrlEncodedData, TestErrorCodeData, TypesData, TypesResponse, UploadFileData, UploadFileResponse } from '../types.gen';
 
 export type QueryKey<TOptions extends Options> = [
     Pick<TOptions, 'path'> & {
@@ -44,7 +44,7 @@ const createQueryKey = <TOptions extends Options>(id: string, options?: TOptions
 
 export const exportQueryKey = (options?: Options<ExportData>) => createQueryKey('export', options);
 
-export const exportQuery = defineQueryOptions((options?: Options<ExportData>) => ({
+export const exportQuery = defineQueryOptions<Options<ExportData>, unknown, Error>((options?: Options<ExportData>) => ({
     key: exportQueryKey(options),
     query: async (context) => {
         const { data } = await export_({
@@ -91,7 +91,7 @@ export const fooWowMutation = (options?: Partial<Options<FooWowData>>): UseMutat
 
 export const apiVVersionODataControllerCountQueryKey = (options?: Options<ApiVVersionODataControllerCountData>) => createQueryKey('apiVVersionODataControllerCount', options);
 
-export const apiVVersionODataControllerCountQuery = defineQueryOptions((options?: Options<ApiVVersionODataControllerCountData>) => ({
+export const apiVVersionODataControllerCountQuery = defineQueryOptions<Options<ApiVVersionODataControllerCountData>, ApiVVersionODataControllerCountResponse, Error>((options?: Options<ApiVVersionODataControllerCountData>) => ({
     key: apiVVersionODataControllerCountQueryKey(options),
     query: async (context) => {
         const { data } = await apiVVersionODataControllerCount({
@@ -105,7 +105,7 @@ export const apiVVersionODataControllerCountQuery = defineQueryOptions((options?
 
 export const getApiVbyApiVersionSimpleOperationQueryKey = (options: Options<GetApiVbyApiVersionSimpleOperationData>) => createQueryKey('getApiVbyApiVersionSimpleOperation', options);
 
-export const getApiVbyApiVersionSimpleOperationQuery = defineQueryOptions((options: Options<GetApiVbyApiVersionSimpleOperationData>) => ({
+export const getApiVbyApiVersionSimpleOperationQuery = defineQueryOptions<Options<GetApiVbyApiVersionSimpleOperationData>, GetApiVbyApiVersionSimpleOperationResponse, GetApiVbyApiVersionSimpleOperationError>((options: Options<GetApiVbyApiVersionSimpleOperationData>) => ({
     key: getApiVbyApiVersionSimpleOperationQueryKey(options),
     query: async (context) => {
         const { data } = await getApiVbyApiVersionSimpleOperation({
@@ -130,7 +130,7 @@ export const deleteCallWithoutParametersAndResponseMutation = (options?: Partial
 
 export const getCallWithoutParametersAndResponseQueryKey = (options?: Options<GetCallWithoutParametersAndResponseData>) => createQueryKey('getCallWithoutParametersAndResponse', options);
 
-export const getCallWithoutParametersAndResponseQuery = defineQueryOptions((options?: Options<GetCallWithoutParametersAndResponseData>) => ({
+export const getCallWithoutParametersAndResponseQuery = defineQueryOptions<Options<GetCallWithoutParametersAndResponseData>, unknown, Error>((options?: Options<GetCallWithoutParametersAndResponseData>) => ({
     key: getCallWithoutParametersAndResponseQueryKey(options),
     query: async (context) => {
         const { data } = await getCallWithoutParametersAndResponse({
@@ -235,7 +235,7 @@ export const callWithWeirdParameterNamesMutation = (options?: Partial<Options<Ca
 
 export const getCallWithOptionalParamQueryKey = (options: Options<GetCallWithOptionalParamData>) => createQueryKey('getCallWithOptionalParam', options);
 
-export const getCallWithOptionalParamQuery = defineQueryOptions((options: Options<GetCallWithOptionalParamData>) => ({
+export const getCallWithOptionalParamQuery = defineQueryOptions<Options<GetCallWithOptionalParamData>, unknown, Error>((options: Options<GetCallWithOptionalParamData>) => ({
     key: getCallWithOptionalParamQueryKey(options),
     query: async (context) => {
         const { data } = await getCallWithOptionalParam({
@@ -282,7 +282,7 @@ export const postApiVbyApiVersionFormDataMutation = (options?: Partial<Options<P
 
 export const callWithDefaultParametersQueryKey = (options?: Options<CallWithDefaultParametersData>) => createQueryKey('callWithDefaultParameters', options);
 
-export const callWithDefaultParametersQuery = defineQueryOptions((options?: Options<CallWithDefaultParametersData>) => ({
+export const callWithDefaultParametersQuery = defineQueryOptions<Options<CallWithDefaultParametersData>, unknown, Error>((options?: Options<CallWithDefaultParametersData>) => ({
     key: callWithDefaultParametersQueryKey(options),
     query: async (context) => {
         const { data } = await callWithDefaultParameters({
@@ -329,7 +329,7 @@ export const duplicateNameMutation = (options?: Partial<Options<DuplicateNameDat
 
 export const duplicateName2QueryKey = (options?: Options<DuplicateName2Data>) => createQueryKey('duplicateName2', options);
 
-export const duplicateName2Query = defineQueryOptions((options?: Options<DuplicateName2Data>) => ({
+export const duplicateName2Query = defineQueryOptions<Options<DuplicateName2Data>, unknown, Error>((options?: Options<DuplicateName2Data>) => ({
     key: duplicateName2QueryKey(options),
     query: async (context) => {
         const { data } = await duplicateName2({
@@ -365,7 +365,7 @@ export const duplicateName4Mutation = (options?: Partial<Options<DuplicateName4D
 
 export const callWithNoContentResponseQueryKey = (options?: Options<CallWithNoContentResponseData>) => createQueryKey('callWithNoContentResponse', options);
 
-export const callWithNoContentResponseQuery = defineQueryOptions((options?: Options<CallWithNoContentResponseData>) => ({
+export const callWithNoContentResponseQuery = defineQueryOptions<Options<CallWithNoContentResponseData>, CallWithNoContentResponseResponse, Error>((options?: Options<CallWithNoContentResponseData>) => ({
     key: callWithNoContentResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithNoContentResponse({
@@ -379,7 +379,7 @@ export const callWithNoContentResponseQuery = defineQueryOptions((options?: Opti
 
 export const callWithResponseAndNoContentResponseQueryKey = (options?: Options<CallWithResponseAndNoContentResponseData>) => createQueryKey('callWithResponseAndNoContentResponse', options);
 
-export const callWithResponseAndNoContentResponseQuery = defineQueryOptions((options?: Options<CallWithResponseAndNoContentResponseData>) => ({
+export const callWithResponseAndNoContentResponseQuery = defineQueryOptions<Options<CallWithResponseAndNoContentResponseData>, CallWithResponseAndNoContentResponseResponse, Error>((options?: Options<CallWithResponseAndNoContentResponseData>) => ({
     key: callWithResponseAndNoContentResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithResponseAndNoContentResponse({
@@ -393,7 +393,7 @@ export const callWithResponseAndNoContentResponseQuery = defineQueryOptions((opt
 
 export const dummyAQueryKey = (options?: Options<DummyAData>) => createQueryKey('dummyA', options);
 
-export const dummyAQuery = defineQueryOptions((options?: Options<DummyAData>) => ({
+export const dummyAQuery = defineQueryOptions<Options<DummyAData>, DummyAResponse, Error>((options?: Options<DummyAData>) => ({
     key: dummyAQueryKey(options),
     query: async (context) => {
         const { data } = await dummyA({
@@ -407,7 +407,7 @@ export const dummyAQuery = defineQueryOptions((options?: Options<DummyAData>) =>
 
 export const dummyBQueryKey = (options?: Options<DummyBData>) => createQueryKey('dummyB', options);
 
-export const dummyBQuery = defineQueryOptions((options?: Options<DummyBData>) => ({
+export const dummyBQuery = defineQueryOptions<Options<DummyBData>, DummyBResponse, Error>((options?: Options<DummyBData>) => ({
     key: dummyBQueryKey(options),
     query: async (context) => {
         const { data } = await dummyB({
@@ -421,7 +421,7 @@ export const dummyBQuery = defineQueryOptions((options?: Options<DummyBData>) =>
 
 export const callWithResponseQueryKey = (options?: Options<CallWithResponseData>) => createQueryKey('callWithResponse', options);
 
-export const callWithResponseQuery = defineQueryOptions((options?: Options<CallWithResponseData>) => ({
+export const callWithResponseQuery = defineQueryOptions<Options<CallWithResponseData>, CallWithResponseResponse, Error>((options?: Options<CallWithResponseData>) => ({
     key: callWithResponseQueryKey(options),
     query: async (context) => {
         const { data } = await callWithResponse({
@@ -457,7 +457,7 @@ export const callWithResponsesMutation = (options?: Partial<Options<CallWithResp
 
 export const collectionFormatQueryKey = (options: Options<CollectionFormatData>) => createQueryKey('collectionFormat', options);
 
-export const collectionFormatQuery = defineQueryOptions((options: Options<CollectionFormatData>) => ({
+export const collectionFormatQuery = defineQueryOptions<Options<CollectionFormatData>, unknown, Error>((options: Options<CollectionFormatData>) => ({
     key: collectionFormatQueryKey(options),
     query: async (context) => {
         const { data } = await collectionFormat({
@@ -471,7 +471,7 @@ export const collectionFormatQuery = defineQueryOptions((options: Options<Collec
 
 export const typesQueryKey = (options: Options<TypesData>) => createQueryKey('types', options);
 
-export const typesQuery = defineQueryOptions((options: Options<TypesData>) => ({
+export const typesQuery = defineQueryOptions<Options<TypesData>, TypesResponse, Error>((options: Options<TypesData>) => ({
     key: typesQueryKey(options),
     query: async (context) => {
         const { data } = await types({
@@ -496,7 +496,7 @@ export const uploadFileMutation = (options?: Partial<Options<UploadFileData>>): 
 
 export const fileResponseQueryKey = (options: Options<FileResponseData>) => createQueryKey('fileResponse', options);
 
-export const fileResponseQuery = defineQueryOptions((options: Options<FileResponseData>) => ({
+export const fileResponseQuery = defineQueryOptions<Options<FileResponseData>, FileResponseResponse, Error>((options: Options<FileResponseData>) => ({
     key: fileResponseQueryKey(options),
     query: async (context) => {
         const { data } = await fileResponse({
@@ -510,7 +510,7 @@ export const fileResponseQuery = defineQueryOptions((options: Options<FileRespon
 
 export const complexTypesQueryKey = (options: Options<ComplexTypesData>) => createQueryKey('complexTypes', options);
 
-export const complexTypesQuery = defineQueryOptions((options: Options<ComplexTypesData>) => ({
+export const complexTypesQuery = defineQueryOptions<Options<ComplexTypesData>, ComplexTypesResponse, Error>((options: Options<ComplexTypesData>) => ({
     key: complexTypesQueryKey(options),
     query: async (context) => {
         const { data } = await complexTypes({
@@ -524,7 +524,7 @@ export const complexTypesQuery = defineQueryOptions((options: Options<ComplexTyp
 
 export const multipartResponseQueryKey = (options?: Options<MultipartResponseData>) => createQueryKey('multipartResponse', options);
 
-export const multipartResponseQuery = defineQueryOptions((options?: Options<MultipartResponseData>) => ({
+export const multipartResponseQuery = defineQueryOptions<Options<MultipartResponseData>, MultipartResponseResponse, Error>((options?: Options<MultipartResponseData>) => ({
     key: multipartResponseQueryKey(options),
     query: async (context) => {
         const { data } = await multipartResponse({

--- a/packages/openapi-ts/src/plugins/@pinia/colada/queryOptions.ts
+++ b/packages/openapi-ts/src/plugins/@pinia/colada/queryOptions.ts
@@ -12,6 +12,7 @@ import { $ } from '../../../ts-dsl';
 import { handleMeta } from './meta';
 import { createQueryKeyFunction, createQueryKeyType, queryKeyStatement } from './queryKey';
 import type { PiniaColadaPlugin } from './types';
+import { useTypeError, useTypeResponse } from './useType';
 import { getPublicTypeData } from './utils';
 
 const optionsParamName = 'options';
@@ -125,11 +126,17 @@ export const createQueryOptions = ({
     .export()
     .$if(plugin.config.comments && createOperationComment(operation), (c, v) => c.doc(v))
     .assign(
-      $(symbolDefineQueryOptions).call(
-        $.func()
-          .param(optionsParamName, (p) => p.required(isRequiredOptions).type(typeData))
-          .do($.return(queryOpts)),
-      ),
+      $(symbolDefineQueryOptions)
+        .call(
+          $.func()
+            .param(optionsParamName, (p) => p.required(isRequiredOptions).type(typeData))
+            .do($.return(queryOpts)),
+        )
+        .generics(
+          typeData,
+          useTypeResponse({ operation, plugin }),
+          useTypeError({ operation, plugin }),
+        ),
     );
   plugin.node(statement);
 };


### PR DESCRIPTION
## Summary

- Adds `TError` (and `TData`, `TResponse`) type generics to `defineQueryOptions` calls in the @pinia/colada plugin
- Previously only mutations had correctly typed errors via `UseMutationOptions<TResponse, TData, TError>`, while queries defaulted to `ErrorDefault` (`Error`)

Closes #3482

## Test plan

- [x] All 111 plugin tests pass
- [x] 6 pinia/colada snapshots updated to include generics on `defineQueryOptions`