### PR TITLE
fix: support output header function signature in client and core files

### DIFF
--- a/.changeset/bitter-lines-hammer.md
+++ b/.changeset/bitter-lines-hammer.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/shared": patch
+---
+
+**output**: context file is optional

--- a/.changeset/poor-beds-arrive.md
+++ b/.changeset/poor-beds-arrive.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**output(header)**: fix: support function signature in client and core files

--- a/packages/openapi-python/src/generate/client.ts
+++ b/packages/openapi-python/src/generate/client.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import type { IProject, ProjectRenderMeta } from '@hey-api/codegen-core';
 import type { DefinePlugin, OutputHeader } from '@hey-api/shared';
-import { ensureDirSync } from '@hey-api/shared';
+import { ensureDirSync, outputHeaderToPrefix } from '@hey-api/shared';
 
 import type { Config } from '../config/types';
 import type { Client } from '../plugins/@hey-api/client-core/types';
@@ -51,21 +51,6 @@ function getClientBundlePaths(pluginName: string): {
     clientPath: path.resolve(__dirname, 'clients', clientName),
     corePath: path.resolve(__dirname, 'clients', 'core'),
   };
-}
-
-/**
- * Converts an {@link OutputHeader} value to a string prefix for file content.
- * Returns an empty string when the header is null, undefined, or a function
- * (functions require a render context which is not available for bundled files).
- */
-function outputHeaderToPrefix(header: OutputHeader): string {
-  if (header == null || typeof header === 'function') return '';
-  const lines =
-    typeof header === 'string'
-      ? header.split(/\r?\n/)
-      : header.flatMap((line) => line.split(/\r?\n/));
-  const content = lines.join('\n');
-  return content ? `${content}\n\n` : '';
 }
 
 /**
@@ -186,11 +171,11 @@ export function generateClientBundle({
   meta: ProjectRenderMeta;
   outputPath: string;
   plugin: DefinePlugin<Client.Config & { name: string }>['Config'];
-  project?: IProject;
+  project: IProject;
 }): Map<string, string> | undefined {
   const renamed = new Map<string, string>();
   const devMode = isDevMode();
-  const headerPrefix = outputHeaderToPrefix(header);
+  const headerPrefix = outputHeaderToPrefix(header, project);
 
   // copy Hey API clients to output
   const isHeyApiClientPlugin = plugin.name.startsWith('@hey-api/client-');

--- a/packages/openapi-ts/src/generate/client.ts
+++ b/packages/openapi-ts/src/generate/client.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 import type { IProject, ProjectRenderMeta } from '@hey-api/codegen-core';
 import type { DefinePlugin, OutputHeader } from '@hey-api/shared';
-import { ensureDirSync } from '@hey-api/shared';
+import { ensureDirSync, outputHeaderToPrefix } from '@hey-api/shared';
 
 import type { Config } from '../config/types';
 import type { Client } from '../plugins/@hey-api/client-core/types';
@@ -51,21 +51,6 @@ function getClientBundlePaths(pluginName: string): {
     clientPath: path.resolve(__dirname, 'clients', clientName),
     corePath: path.resolve(__dirname, 'clients', 'core'),
   };
-}
-
-/**
- * Converts an {@link OutputHeader} value to a string prefix for file content.
- * Returns an empty string when the header is null, undefined, or a function
- * (functions require a render context which is not available for bundled files).
- */
-function outputHeaderToPrefix(header: OutputHeader): string {
-  if (header == null || typeof header === 'function') return '';
-  const lines =
-    typeof header === 'string'
-      ? header.split(/\r?\n/)
-      : header.flatMap((line) => line.split(/\r?\n/));
-  const content = lines.join('\n');
-  return content ? `${content}\n\n` : '';
 }
 
 /**
@@ -186,11 +171,11 @@ export function generateClientBundle({
   meta: ProjectRenderMeta;
   outputPath: string;
   plugin: DefinePlugin<Client.Config & { name: string }>['Config'];
-  project?: IProject;
+  project: IProject;
 }): Map<string, string> | undefined {
   const renamed = new Map<string, string>();
   const devMode = isDevMode();
-  const headerPrefix = outputHeaderToPrefix(header);
+  const headerPrefix = outputHeaderToPrefix(header, project);
 
   // copy Hey API clients to output
   const isHeyApiClientPlugin = plugin.name.startsWith('@hey-api/client-');

--- a/packages/shared/src/config/output/types.ts
+++ b/packages/shared/src/config/output/types.ts
@@ -1,4 +1,8 @@
 import type { RenderContext } from '@hey-api/codegen-core';
 import type { MaybeArray, MaybeFunc } from '@hey-api/types';
 
-export type OutputHeader = MaybeFunc<(ctx: RenderContext) => MaybeArray<string> | null | undefined>;
+export type OutputHeader = MaybeFunc<
+  (
+    ctx: Omit<RenderContext, 'file'> & Pick<Partial<RenderContext>, 'file'>,
+  ) => MaybeArray<string> | null | undefined
+>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -113,6 +113,7 @@ export type { Logs } from './types/logs';
 export type { WatchValues } from './types/watch';
 export { escapeComment } from './utils/escape';
 export { utils } from './utils/exports';
+export { outputHeaderToPrefix } from './utils/header';
 export { inputToApiRegistry } from './utils/input';
 export { heyApiRegistryBaseUrl } from './utils/input/heyApi';
 export { MinHeap } from './utils/minHeap';

--- a/packages/shared/src/utils/header.ts
+++ b/packages/shared/src/utils/header.ts
@@ -1,0 +1,15 @@
+import type { IProject } from '@hey-api/codegen-core';
+
+import type { OutputHeader } from '../config/output/types';
+
+/**
+ * Converts an {@link OutputHeader} value to a string prefix for file content.
+ */
+export function outputHeaderToPrefix(header: OutputHeader, project: IProject): string {
+  let lines = typeof header === 'function' ? header({ project }) : header;
+  if (lines === null || lines === undefined) return '';
+  lines =
+    typeof lines === 'string' ? lines.split(/\r?\n/) : lines.flatMap((line) => line.split(/\r?\n/));
+  const content = lines.join('\n');
+  return content ? `${content}\n\n` : '';
+}


### PR DESCRIPTION
Fixes https://github.com/hey-api/openapi-ts/issues/3484