### PR TITLE
docs: fix useQuery.enabled @default tag from true to false

### DIFF
--- a/packages/openapi-ts/src/plugins/@tanstack/react-query/types.ts
+++ b/packages/openapi-ts/src/plugins/@tanstack/react-query/types.ts
@@ -354,7 +354,7 @@ export type UserConfig = Plugin.Name<'@tanstack/react-query'> &
           /**
            * Whether this feature is enabled.
            *
-           * @default true
+           * @default false
            */
           enabled?: boolean;
           /**


### PR DESCRIPTION
## Summary

I was working on the tanstack query options thing we discussed earlier, ran into this issue and decided to fix it separately.

- Fixes `@default true` to `@default false` in `useQuery.enabled` JSDoc for `@tanstack/react-query` plugin
- The actual default in `config.ts` is `false`, but the types documentation said `true`

Closes #3501