### PR TITLE
fix(client-fetch): throw Error instances for HTTP throwOnError

### DIFF
--- a/examples/openapi-ts-fastify/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/examples/openapi-ts-fetch/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/examples/openapi-ts-nestjs/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-nestjs/src/client/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/examples/openapi-ts-openai/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-openai/src/client/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/examples/openapi-ts-pinia-colada/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/examples/openapi-ts-tanstack-react-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/examples/openapi-ts-tanstack-vue-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -19,6 +19,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -222,7 +266,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/__tests__/client.test.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/__tests__/client.test.ts
@@ -538,3 +538,60 @@ describe('error interceptor for fetch exceptions', () => {
     expect(result.error).toBe(abortError);
   });
 });
+
+describe('throwOnError for HTTP error responses', () => {
+  it('throws an Error instance with status and parsed body', async () => {
+    const client = createClient({ baseUrl: 'https://example.com' });
+    const mockResponse = new Response(
+      JSON.stringify({ message: 'auth.unauthenticated.wrong_token' }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        status: 401,
+      },
+    );
+    const mockFetch: MockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+    let thrownError: unknown;
+    try {
+      await client.get({
+        fetch: mockFetch,
+        throwOnError: true,
+        url: '/protected',
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect(thrownError).toMatchObject({
+      body: { message: 'auth.unauthenticated.wrong_token' },
+      message: 'auth.unauthenticated.wrong_token',
+      status: 401,
+    });
+  });
+
+  it('falls back to a status-based message when body has no message', async () => {
+    const client = createClient({ baseUrl: 'https://example.com' });
+    const mockResponse = new Response(JSON.stringify({ error: 'unauthorized' }), {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      status: 403,
+    });
+    const mockFetch: MockFetch = vi.fn().mockResolvedValue(mockResponse);
+
+    await expect(
+      client.get({
+        fetch: mockFetch,
+        throwOnError: true,
+        url: '/protected',
+      }),
+    ).rejects.toMatchObject({
+      body: { error: 'unauthorized' },
+      message: 'Request failed with status 403',
+      status: 403,
+    });
+  });
+});

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
@@ -17,6 +17,50 @@ type ReqInit = Omit<RequestInit, 'body' | 'headers'> & {
   headers: ReturnType<typeof mergeHeaders>;
 };
 
+const createHttpError = ({
+  error,
+  request,
+  response,
+}: {
+  error: unknown;
+  request: Request;
+  response: Response;
+}) => {
+  if (error instanceof Error) {
+    const enrichedError = error as Error & {
+      body?: unknown;
+      request?: Request;
+      response?: Response;
+      status?: number;
+    };
+
+    enrichedError.body ??= error;
+    enrichedError.request ??= request;
+    enrichedError.response ??= response;
+    enrichedError.status ??= response.status;
+    return enrichedError;
+  }
+
+  const message =
+    typeof error === 'string'
+      ? error
+      : ((error as { message?: unknown })?.message ??
+        `Request failed with status ${response.status}`);
+
+  const httpError = new Error(String(message)) as Error & {
+    body: unknown;
+    request: Request;
+    response: Response;
+    status: number;
+  };
+
+  httpError.body = error;
+  httpError.request = request;
+  httpError.response = response;
+  httpError.status = response.status;
+  return httpError;
+};
+
 export const createClient = (config: Config = {}): Client => {
   let _config = mergeConfigs(createConfig(), config);
 
@@ -220,7 +264,11 @@ export const createClient = (config: Config = {}): Client => {
     finalError = finalError || ({} as string);
 
     if (opts.throwOnError) {
-      throw finalError;
+      throw createHttpError({
+        error: finalError,
+        request,
+        response,
+      });
     }
 
     // TODO: we probably want to return error and improve types


### PR DESCRIPTION
Related https://github.com/hey-api/openapi-ts/issues/3632

## Summary

- throw an Error instance (instead of raw JSON/object) for HTTP failures when throwOnError is enabled
- preserve status, body, request, and response on the thrown error
- keep existing fetch-exception interceptor behavior unchanged
- add regression tests for:
  - JSON error payload with message
  - status-based fallback message when payload has no message

## Validation

- pnpm exec vitest run --config /tmp/vitest-single.config.ts packages/openapi-ts/src/plugins/@hey-api/client-fetch/__tests__/client.test.ts
- result: 33 passed, 0 failed