### PR TITLE
chore: bump typescript peer dependency range

### DIFF
--- a/.changeset/ninety-moose-exist.md
+++ b/.changeset/ninety-moose-exist.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**internal**: expand TypeScript peer dependency range

--- a/packages/openapi-ts/package.json
+++ b/packages/openapi-ts/package.json
@@ -98,7 +98,7 @@
     "zone.js": "0.16.0"
   },
   "peerDependencies": {
-    "typescript": ">=5.5.3 || 6.0.1-rc"
+    "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc"
   },
   "engines": {
     "node": ">=20.19.0"


### PR DESCRIPTION
Related https://github.com/hey-api/openapi-ts/issues/3572