### PR TITLE
fix(client-fetch): type response as Response | undefined in error interceptors

### DIFF
--- a/.changeset/fix-error-interceptor-response-type.md
+++ b/.changeset/fix-error-interceptor-response-type.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-fetch)**: type `response` as `Response | undefined` in error interceptors and error results, since `response` is `undefined` when the error originates from a fetch exception (e.g. network failure, AbortError)

--- a/examples/openapi-ts-fastify/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/examples/openapi-ts-fastify/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/client/types.gen.ts
@@ -124,7 +124,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/examples/openapi-ts-fastify/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/examples/openapi-ts-fastify/test/pets.test.ts
+++ b/examples/openapi-ts-fastify/test/pets.test.ts
@@ -26,6 +26,6 @@ describe('/pet/findByTags', () => {
         petId: '123',
       },
     });
-    expect(result.response.status).toBe(200);
+    expect(result.response?.status).toBe(200);
   });
 });

--- a/examples/openapi-ts-fetch/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/examples/openapi-ts-fetch/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/client/types.gen.ts
@@ -124,7 +124,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/examples/openapi-ts-fetch/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/examples/openapi-ts-nestjs/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-nestjs/src/client/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/examples/openapi-ts-nestjs/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-nestjs/src/client/client/types.gen.ts
@@ -124,7 +124,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/examples/openapi-ts-nestjs/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-nestjs/src/client/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/examples/openapi-ts-nestjs/test/pets.test.ts
+++ b/examples/openapi-ts-nestjs/test/pets.test.ts
@@ -28,7 +28,7 @@ afterAll(async () => {
 describe('PetsController', () => {
   test('listPets', async () => {
     const result = await listPets({ client });
-    expect(result.response.status).toBe(200);
+    expect(result.response?.status).toBe(200);
     expect(Array.isArray(result.data)).toBe(true);
   });
 
@@ -37,7 +37,7 @@ describe('PetsController', () => {
       client,
       path: { petId: '1' },
     });
-    expect(result.response.status).toBe(200);
+    expect(result.response?.status).toBe(200);
   });
 
   test('createPet', async () => {
@@ -45,7 +45,7 @@ describe('PetsController', () => {
       body: { name: 'Buddy' },
       client,
     });
-    expect(result.response.status).toBe(201);
+    expect(result.response?.status).toBe(201);
     expect(result.data).toMatchObject({ name: 'Buddy' });
   });
 });
@@ -53,6 +53,6 @@ describe('PetsController', () => {
 describe('StoreController', () => {
   test('getInventory', async () => {
     const result = await getInventory({ client });
-    expect(result.response.status).toBe(200);
+    expect(result.response?.status).toBe(200);
   });
 });

--- a/examples/openapi-ts-openai/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-openai/src/client/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/examples/openapi-ts-openai/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-openai/src/client/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/examples/openapi-ts-openai/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-openai/src/client/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/examples/openapi-ts-pinia-colada/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/examples/openapi-ts-pinia-colada/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/client/types.gen.ts
@@ -124,7 +124,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/examples/openapi-ts-pinia-colada/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/examples/openapi-ts-tanstack-react-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/examples/openapi-ts-tanstack-react-query/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/client/types.gen.ts
@@ -124,7 +124,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/examples/openapi-ts-tanstack-react-query/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/client/types.gen.ts
@@ -124,7 +124,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/examples/openapi-ts-tanstack-vue-query/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/examples/openapi-ts-tanstack-vue-query/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/client/types.gen.ts
@@ -124,7 +124,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/examples/openapi-ts-tanstack-vue-query/src/client/client/utils.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/client.gen.ts
+++ b/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/types.gen.ts
+++ b/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-tanstack-react-query/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-tanstack-react-query/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-tanstack-react-query/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-tanstack-react-query/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-tanstack-react-query/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-tanstack-react-query/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/client.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/client.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/client.gen.ts
@@ -103,7 +103,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -119,7 +119,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/types.gen.ts
@@ -127,7 +127,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/utils.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/utils.gen.ts
@@ -218,7 +218,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/client.ts
@@ -101,7 +101,7 @@ export const createClient = (config: Config = {}): Client => {
 
       for (const fn of interceptors.error.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown;
+          finalError = (await fn(error, undefined, request, opts)) as unknown;
         }
       }
 
@@ -117,7 +117,7 @@ export const createClient = (config: Config = {}): Client => {
         : {
             error: finalError,
             request,
-            response: undefined as any,
+            response: undefined,
           };
     }
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/types.ts
@@ -125,7 +125,7 @@ export type RequestResult<
               }
           ) & {
             request: Request;
-            response: Response;
+            response: Response | undefined;
           }
     >;
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/utils.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/utils.ts
@@ -216,7 +216,7 @@ export const mergeHeaders = (
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
+  response: Res | undefined,
   request: Req,
   options: Options,
 ) => Err | Promise<Err>;


### PR DESCRIPTION
Fixes #3519

The `ErrInterceptor` type and `RequestResult` type incorrectly typed `response` as always-defined `Response`. When `fetch()` throws (network failure, `AbortError`, etc.), the error interceptor receives `undefined` for `response`, and the error result also returns `undefined` for `response`.

Changes:
- `ErrInterceptor`: `response` parameter is now `Res | undefined`
- `RequestResult` (non-throw error branch): `response` is now `Response | undefined`
- Removes `undefined as any` casts in the client implementation