### PR TITLE
fix(client-fetch): narrow headers to Headers in ResolvedRequestOptions

### DIFF
--- a/.changeset/fix-resolved-request-options-headers.md
+++ b/.changeset/fix-resolved-request-options-headers.md
@@ -2,4 +2,4 @@
 "@hey-api/openapi-ts": patch
 ---
 
-**plugin(@hey-api/client-fetch)**: narrow `headers` to `Headers` in `ResolvedRequestOptions` so request interceptors can use `.set()`, `.get()`, etc. without casting
+**plugin(@hey-api/client-fetch)**: fix: narrow `headers` to `Headers` in `ResolvedRequestOptions`

--- a/.changeset/fix-resolved-request-options-headers.md
+++ b/.changeset/fix-resolved-request-options-headers.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-fetch)**: narrow `headers` to `Headers` in `ResolvedRequestOptions` so request interceptors can use `.set()`, `.get()`, etc. without casting

--- a/.changeset/mighty-toes-dress.md
+++ b/.changeset/mighty-toes-dress.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-next)**: fix: narrow `headers` to `Headers` in `ResolvedRequestOptions`

--- a/.changeset/plenty-games-smash.md
+++ b/.changeset/plenty-games-smash.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-ky)**: fix: narrow `headers` to `Headers` in `ResolvedRequestOptions`

--- a/.changeset/small-drinks-march.md
+++ b/.changeset/small-drinks-march.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-angular)**: fix: narrow `headers` to `Headers` in `ResolvedRequestOptions`

--- a/.changeset/tough-swans-invite.md
+++ b/.changeset/tough-swans-invite.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**plugin(@hey-api/client-ofetch)**: fix: narrow `headers` to `Headers` in `ResolvedRequestOptions`

--- a/examples/openapi-ts-angular-common/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-angular-common/src/client/client/types.gen.ts
@@ -97,6 +97,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-angular/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-angular/src/client/client/types.gen.ts
@@ -97,6 +97,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-fastify/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-fastify/src/client/client/types.gen.ts
@@ -90,6 +90,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-fetch/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-fetch/src/client/client/types.gen.ts
@@ -90,6 +90,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-ky/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-ky/src/client/client/types.gen.ts
@@ -122,6 +122,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-nestjs/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-nestjs/src/client/client/types.gen.ts
@@ -90,6 +90,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-next/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-next/src/client/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/examples/openapi-ts-next/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-next/src/client/client/types.gen.ts
@@ -72,6 +72,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-ofetch/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-ofetch/src/client/client/types.gen.ts
@@ -153,6 +153,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-openai/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-openai/src/client/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-pinia-colada/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-pinia-colada/src/client/client/types.gen.ts
@@ -90,6 +90,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/types.gen.ts
@@ -97,6 +97,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-tanstack-react-query/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-tanstack-react-query/src/client/client/types.gen.ts
@@ -90,6 +90,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-tanstack-svelte-query/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-tanstack-svelte-query/src/client/client/types.gen.ts
@@ -90,6 +90,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/examples/openapi-ts-tanstack-vue-query/src/client/client/types.gen.ts
+++ b/examples/openapi-ts-tanstack-vue-query/src/client/client/types.gen.ts
@@ -90,6 +90,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/types.gen.ts
+++ b/packages/openapi-ts-tests/__snapshots__/plugins/@tanstack/meta/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/body-response-text-plain/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/form-data/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/default/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@pinia/colada/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/schema-unknown/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-api-key/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-basic/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-false/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/security-oauth2/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-base-path/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers-host/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/servers/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/transforms-read-write/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-binary-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/body-response-text-plain/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/internal-name-conflict/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/parameter-explode-false/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/default/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@pinia/colada/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-api-key/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-false/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-http-bearer/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-oauth2/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/security-open-id-connect/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/servers/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-all-of/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-allof-response-wrapper/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-any-of-null/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-array/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transformers-recursive/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/transforms-read-write/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/body-response-text-plain/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-false/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-number/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-strict/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/base-url-string/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/clean-false/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/default/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/import-file-extension-ts/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-optional/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/sdk-client-required/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-node16-sdk/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-fetch/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-false/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-number/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-strict/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/base-url-string/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/clean-false/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/default/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/import-file-extension-ts/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-optional/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/sdk-client-required/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-node16-sdk/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ky/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -125,6 +125,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-false/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-number/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-strict/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/base-url-string/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/clean-false/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/default/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/import-file-extension-ts/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-optional/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/sdk-client-required/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-node16-sdk/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-next/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-false/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-number/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-number/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-strict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-strict/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-string/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/base-url-string/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/clean-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/clean-false/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/default/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/import-file-extension-ts/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/import-file-extension-ts/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-optional/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-optional/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-required/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/sdk-client-required/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-node16-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-node16-sdk/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-nodenext-sdk/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-ofetch/tsconfig-nodenext-sdk/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/headers/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/internal-name-conflict/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/pagination-ref/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/parameter-explode-false/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes-instance/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/client-fetch/sdk-nested-classes/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/default/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/instance/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/sdk/throwOnError/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-custom-name/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@hey-api/typescript/transforms-read-write-ignore/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@pinia/colada/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/angular-query-experimental/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/preact-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/react-query/useMutation/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/solid-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/svelte-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/asClass/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@tanstack/vue-query/name-builder/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-api-key/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-false/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-http-bearer/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-oauth2/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/security-open-id-connect/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/servers/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/types.gen.ts
@@ -100,6 +100,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/client.gen.ts
@@ -220,7 +220,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/client/types.gen.ts
@@ -75,6 +75,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-ofetch/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-ofetch/client/types.gen.ts
@@ -156,6 +156,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-tanstack-react-query/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-tanstack-react-query/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-additional-properties/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-all-of/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-allof-response-wrapper/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-any-of-null/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-array/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-one-of-discriminated/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transformers-recursive/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/types.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/transforms-read-write/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/class/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/flat/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/method-class-conflict/instance/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/types.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/valibot/v1/__snapshots__/3.1.x/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/mini/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v3/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/2.0.x/v4/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/mini/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v3/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.0.x/v4/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/mini/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v3/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/types.gen.ts
+++ b/packages/openapi-ts-tests/zod/v4/__snapshots__/3.1.x/v4/type-format/client/types.gen.ts
@@ -93,6 +93,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/types.ts
@@ -98,6 +98,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: HttpHeaders;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-fetch/bundle/types.ts
@@ -91,6 +91,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ky/bundle/types.ts
@@ -123,6 +123,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/client.ts
@@ -218,7 +218,7 @@ export const createClient = (config: Config = {}): Client => {
         };
         for (const fn of interceptors.request.fns) {
           if (fn) {
-            await fn(requestInit);
+            await fn(requestInit as unknown as ResolvedRequestOptions);
             request = new Request(requestInit.url, requestInit);
           }
         }

--- a/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-next/bundle/types.ts
@@ -73,6 +73,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 

--- a/packages/openapi-ts/src/plugins/@hey-api/client-ofetch/bundle/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-ofetch/bundle/types.ts
@@ -154,6 +154,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers;
   serializedBody?: string;
 }
 


### PR DESCRIPTION
Fixes #3372

`ResolvedRequestOptions.headers` was typed as `RequestInit['headers'] | Record<string, ...>` (inherited from `CoreConfig`), but `mergeHeaders()` always returns a `Headers` instance. This narrowing lets request interceptors use `.set()`, `.get()`, `.delete()` etc. without casting.