### PR TITLE
fix: re-add implicitly-filtered schemas in collectOperations

### DIFF
--- a/.changeset/fix-deprecated-filter-operations.md
+++ b/.changeset/fix-deprecated-filter-operations.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/shared": patch
+---
+
+**parser**: fix: re-add implicitly-filtered schemas in collectOperations

--- a/.changeset/fix-deprecated-filter-operations.md
+++ b/.changeset/fix-deprecated-filter-operations.md
@@ -1,4 +1,5 @@
 ---
+"@hey-api/openapi-ts": patch
 "@hey-api/shared": patch
 ---
 

--- a/packages/shared/src/openApi/shared/utils/__tests__/filter.test.ts
+++ b/packages/shared/src/openApi/shared/utils/__tests__/filter.test.ts
@@ -117,6 +117,38 @@ describe('createFilteredDependencies', () => {
     expect(schemas).toEqual(new Set(['schema/Baz']));
   });
 
+  it('keeps non-deprecated operations that transitively reference deprecated schemas', () => {
+    const filters = createFilters();
+    filters.deprecated = false;
+
+    const resourceMetadata = createResourceMetadata();
+    // Add a deprecated schema referenced via a oneOf in the response
+    resourceMetadata.schemas.set('schema/DeprecatedWidget', {
+      dependencies: new Set(),
+      deprecated: true,
+    });
+    // Operation transitively depends on the deprecated schema
+    resourceMetadata.operations.set('operation/GET /v1/widgets', {
+      dependencies: new Set([
+        'response/UsedResponse',
+        'schema/Foo',
+        'schema/DeprecatedWidget',
+      ]),
+      deprecated: false,
+      tags: new Set(),
+    });
+
+    const { operations, schemas } = createFilteredDependencies({
+      filters,
+      logger: loggerStub,
+      resourceMetadata,
+    });
+
+    expect(operations.has('operation/GET /v1/widgets')).toBe(true);
+    // The deprecated schema should be re-added since the operation needs it
+    expect(schemas.has('schema/DeprecatedWidget')).toBe(true);
+  });
+
   it('prioritizes excludes when the same schema is explicitly included and excluded', () => {
     const filters = createFilters();
     filters.schemas.include.add('schema/Foo');

--- a/packages/shared/src/openApi/shared/utils/filter.ts
+++ b/packages/shared/src/openApi/shared/utils/filter.ts
@@ -433,8 +433,16 @@ function collectOperations({
             return !parameters.has(dependency);
           case 'response':
             return !responses.has(dependency);
-          case 'schema':
-            return !schemas.has(dependency);
+          case 'schema': {
+            if (schemas.has(dependency)) {
+              return false;
+            }
+            if (filters.schemas.exclude.has(dependency)) {
+              return true;
+            }
+            schemas.add(dependency);
+            return false;
+          }
           default:
             return false;
         }


### PR DESCRIPTION
## Problem

When `parser.filters.deprecated: false` is set, `collectOperations` silently drops non-deprecated operations whose transitive dependencies include a deprecated schema (e.g. via `oneOf` unions in response types).

Fixes #3790

## Root Cause

`collectOperations` treats a missing schema dependency as fatal:

```ts
case 'schema':
  return !schemas.has(dependency);
```

Its siblings (`collectParameters`, `collectRequestBodies`, `collectResponses`) instead re-add implicitly-filtered schemas:

```ts
case 'schema':
  if (filters.schemas.exclude.has(dependency)) finalSet.delete(key);
  else if (!schemas.has(dependency)) schemas.add(dependency);
  break;
```

## Fix

Align `collectOperations` with the sibling pattern:

```ts
case 'schema': {
  if (schemas.has(dependency)) return false;
  if (filters.schemas.exclude.has(dependency)) return true;
  schemas.add(dependency);
  return false;
}
```

Consistency fix, not a behavior change.

## Impact

On Apple's App Store Connect OpenAPI spec, 48 non-deprecated operations disappear from the output... including `apps_getCollection`, `apps_getInstance`, and `appStoreVersions_createInstance`. The triggering deprecated schemas sit inside `included` field `oneOf` unions (standard JSON:API pattern).