### PR TITLE
feat(openapi-ts): allow disabling generation of operation types

### DIFF
--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/config.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/config.ts
@@ -44,10 +44,12 @@ export const defaultConfig: HeyApiTypeScriptPlugin['Config'] = {
     plugin.config.errors = context.valueToObject({
       defaultValue: {
         case: plugin.config.case ?? 'PascalCase',
+        enabled: true,
         error: '{{name}}Error',
         name: '{{name}}Errors',
       },
       mappers: {
+        boolean: (enabled) => ({ enabled }),
         function: (name) => ({ name }),
         string: (name) => ({ name }),
       },
@@ -57,9 +59,11 @@ export const defaultConfig: HeyApiTypeScriptPlugin['Config'] = {
     plugin.config.requests = context.valueToObject({
       defaultValue: {
         case: plugin.config.case ?? 'PascalCase',
+        enabled: true,
         name: '{{name}}Data',
       },
       mappers: {
+        boolean: (enabled) => ({ enabled }),
         function: (name) => ({ name }),
         string: (name) => ({ name }),
       },
@@ -69,10 +73,12 @@ export const defaultConfig: HeyApiTypeScriptPlugin['Config'] = {
     plugin.config.responses = context.valueToObject({
       defaultValue: {
         case: plugin.config.case ?? 'PascalCase',
+        enabled: true,
         name: '{{name}}Responses',
         response: '{{name}}Response',
       },
       mappers: {
+        boolean: (enabled) => ({ enabled }),
         function: (name) => ({ name }),
         string: (name) => ({ name }),
       },

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/operation.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/shared/operation.ts
@@ -115,32 +115,34 @@ export const operationToType = ({
     schema: data,
   });
 
-  const dataSymbol = plugin.registerSymbol(
-    buildSymbolIn({
-      meta: {
-        category: 'type',
-        path,
-        resource: 'operation',
-        resourceId: operation.id,
-        role: 'data',
-        tags,
-        tool: 'typescript',
-      },
-      name: operation.id,
-      naming: plugin.config.requests,
-      operation,
-      plugin,
-    }),
-  );
-  const dataNode = $.type
-    .alias(dataSymbol)
-    .export()
-    .type(dataResult?.type ?? $.type('never'));
-  plugin.node(dataNode);
+  if (plugin.config.requests.enabled) {
+    const dataSymbol = plugin.registerSymbol(
+      buildSymbolIn({
+        meta: {
+          category: 'type',
+          path,
+          resource: 'operation',
+          resourceId: operation.id,
+          role: 'data',
+          tags,
+          tool: 'typescript',
+        },
+        name: operation.id,
+        naming: plugin.config.requests,
+        operation,
+        plugin,
+      }),
+    );
+    const dataNode = $.type
+      .alias(dataSymbol)
+      .export()
+      .type(dataResult?.type ?? $.type('never'));
+    plugin.node(dataNode);
+  }
 
   const { error, errors, response, responses } = operationResponsesMap(operation);
 
-  if (errors) {
+  if (plugin.config.errors.enabled && errors) {
     const errorsResult = processor.process({
       export: false,
       meta: {
@@ -205,7 +207,7 @@ export const operationToType = ({
     }
   }
 
-  if (responses) {
+  if (plugin.config.responses.enabled && responses) {
     const responsesResult = processor.process({
       export: false,
       meta: {

--- a/packages/openapi-ts/src/plugins/@hey-api/typescript/types.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/typescript/types.ts
@@ -113,6 +113,12 @@ export type UserConfig = Plugin.Name<'@hey-api/typescript'> &
            */
           case?: Casing;
           /**
+           * Whether this feature is enabled.
+           *
+           * @default true
+           */
+          enabled?: boolean;
+          /**
            * Naming pattern for generated names.
            *
            * @default '{{name}}Error'
@@ -147,6 +153,12 @@ export type UserConfig = Plugin.Name<'@hey-api/typescript'> &
            */
           case?: Casing;
           /**
+           * Whether this feature is enabled.
+           *
+           * @default true
+           */
+          enabled?: boolean;
+          /**
            * Naming pattern for generated names.
            *
            * @default '{{name}}Data'
@@ -173,6 +185,12 @@ export type UserConfig = Plugin.Name<'@hey-api/typescript'> &
            * @default 'PascalCase'
            */
           case?: Casing;
+          /**
+           * Whether this feature is enabled.
+           *
+           * @default true
+           */
+          enabled?: boolean;
           /**
            * Naming pattern for generated names.
            *
@@ -290,30 +308,32 @@ export type Config = Plugin.Name<'@hey-api/typescript'> &
      * - `string` or `function`: Shorthand for `{ name: string | function }`
      * - `object`: Full configuration object
      */
-    errors: NamingOptions & {
-      /**
-       * Naming pattern for generated names.
-       */
-      error: NameTransformer;
-    };
+    errors: FeatureToggle &
+      NamingOptions & {
+        /**
+         * Naming pattern for generated names.
+         */
+        error: NameTransformer;
+      };
     /**
      * Configuration for request-specific types.
      *
      * Controls generation of types for request bodies, query parameters, path
      * parameters, and headers.
      */
-    requests: NamingOptions;
+    requests: FeatureToggle & NamingOptions;
     /**
      * Configuration for response-specific types.
      *
      * Controls generation of types for response bodies and status codes.
      */
-    responses: NamingOptions & {
-      /**
-       * Naming pattern for generated names.
-       */
-      response: NameTransformer;
-    };
+    responses: FeatureToggle &
+      NamingOptions & {
+        /**
+         * Naming pattern for generated names.
+         */
+        response: NameTransformer;
+      };
     /**
      * The top type to use for untyped or unspecified schema values.
      *


### PR DESCRIPTION
### Description

When using `@hey-api/typescript` plugin, I only need the **model/definition types** (e.g., `Pet`, `Order`, `User`, `Category`) from my OpenAPI spec(demo: https://petstore.swagger.io/v2/swagger.json ) — not the operation-related types like `AddPetData`, `AddPetResponse`, `AddPetErrors`, etc.

My project uses its own HTTP client (not `@hey-api/client-*`), so the operation types (`*Data`, `*Response`, `*Errors`) are unnecessary and add noise to the generated output.

### Current Behavior

The `@hey-api/typescript` plugin always generates **all** type categories:

```typescript
// ✅ I want these (model/definition types)
export type Pet = { id?: number; name: string; /* ... */ };
export type Order = { id?: number; petId?: number; /* ... */ };
export type User = { id?: number; username?: string; /* ... */ };

// ❌ I don't need these (operation types)
export type AddPetData = { body: Pet; path?: never; query?: never; url: '/pet'; };
export type AddPetErrors = { 405: unknown; };
export type FindPetsByStatusData = { body?: never; path?: never; query: { status: Array<'available' | 'pending' | 'sold'> }; url: '/pet/findByStatus'; };
export type FindPetsByStatusResponses = { 200: Array<Pet>; };
export type FindPetsByStatusResponse = FindPetsByStatusResponses[keyof FindPetsByStatusResponses];
// ... dozens more operation types
```

The `requests`, `responses`, and `errors` config options only control **naming patterns**, not whether these types are generated at all.

### Expected Behavior

Allow disabling generation of operation types via `false` or `{ enabled: false }`:

```typescript
// openapi-ts.config.ts
export default defineConfig({
  input: './swagger.json',
  output: 'src/types/api-generated',
  plugins: [
    {
      name: '@hey-api/typescript',
      requests: { enabled: false }, // don't generate *Data types
      responses: { enabled: false }, // don't generate *Responses / *Response types
      errors: { enabled: false }, // don't generate *Errors types
    },
  ],
});
```

This would produce a clean `types.gen.ts` containing only model definitions:

```typescript
export type Pet = { id?: number; name: string; /* ... */ };
export type Order = { id?: number; petId?: number; /* ... */ };
export type User = { id?: number; username?: string; /* ... */ };
export type Category = { id?: number; name?: string; };
export type Tag = { id?: number; name?: string; };
```

### Use Case

Many projects use `@hey-api/openapi-ts` **only for type generation** — they have their own HTTP clients (Axios wrappers, uni-app request adapters, custom fetch implementations, etc.) and only need the schema definitions for type-safe request/response typing. For example:

```typescript
import type { Pet } from './api-generated/types.gen';

// Using a custom HTTP client, not @hey-api/client-*
export function getPetById(id: number) {
  return myHttpClient.get<Pet>(`/pet/${id}`);
}
```

In this scenario, the operation types are dead code that clutters the generated output.

### Workaround

Currently I'm using selective re-export as a workaround:

```typescript
// api-spec.ts - manually pick only the model types
export type { Pet, Order, User, Category, Tag } from './api-generated/types.gen';
```

This works but requires manual maintenance whenever the API spec adds new models.

### Environment

- `@hey-api/openapi-ts`: 0.97.1
- Node.js: 22.x
- OS: Windows