### PR TITLE
fix(json-schema-ref-parser): name whole-file $refs after the source filename

### DIFF
--- a/.changeset/whole-file-ref-naming.md
+++ b/.changeset/whole-file-ref-naming.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/json-schema-ref-parser": patch
+---
+
+**bundle**: name whole-file `$ref`s after the source filename instead of the placeholder `root`. Previously, refs like `$ref: './AgentType.yml'` produced schemas named `root`, `<Filename>_root`, etc. They are now named after the source file (`AgentType`, `UserType`, …).

--- a/.changeset/whole-file-ref-naming.md
+++ b/.changeset/whole-file-ref-naming.md
@@ -2,4 +2,4 @@
 "@hey-api/json-schema-ref-parser": patch
 ---
 
-**bundle**: name whole-file `$ref`s after the source filename instead of the placeholder `root`. Previously, refs like `$ref: './AgentType.yml'` produced schemas named `root`, `<Filename>_root`, etc. They are now named after the source file (`AgentType`, `UserType`, …).
+**bundle**: fix: name whole-file `$ref`s after the source filename

--- a/packages/json-schema-ref-parser/src/__tests__/bundle.test.ts
+++ b/packages/json-schema-ref-parser/src/__tests__/bundle.test.ts
@@ -221,6 +221,89 @@ describe('bundle', () => {
     }
   });
 
+  it('names whole-file $refs after the source filename, not "root"', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'json-schema-ref-parser-'));
+
+    try {
+      const agentTypePath = path.join(tempDir, 'AgentType.json');
+      const userTypePath = path.join(tempDir, 'UserType.json');
+      const rootPath = path.join(tempDir, 'root.json');
+
+      // Each external file IS the schema — no #/components/schemas/... fragment.
+      writeJsonFile(agentTypePath, {
+        properties: {
+          kind: { type: 'string' },
+        },
+        type: 'object',
+      });
+
+      writeJsonFile(userTypePath, {
+        properties: {
+          name: { type: 'string' },
+        },
+        type: 'object',
+      });
+
+      writeJsonFile(rootPath, {
+        info: { title: 'Test API', version: '1.0.0' },
+        openapi: '3.0.0',
+        paths: {
+          '/agents': {
+            get: {
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: 'AgentType.json' },
+                    },
+                  },
+                  description: 'ok',
+                },
+              },
+            },
+          },
+          '/users': {
+            get: {
+              responses: {
+                '200': {
+                  content: {
+                    'application/json': {
+                      schema: { $ref: 'UserType.json' },
+                    },
+                  },
+                  description: 'ok',
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const refParser = new $RefParser();
+      const schema = (await refParser.bundle({ pathOrUrlOrSchema: rootPath })) as any;
+      const schemas = (schema.components?.schemas ?? {}) as Record<string, any>;
+      const schemaNames = Object.keys(schemas);
+
+      // The bug: whole-file refs are named "root", "AgentType_root", etc.
+      // (PascalCased downstream into "Root", "AgentTypeRoot".)
+      expect(schemaNames).not.toContain('root');
+      expect(schemaNames.every((name) => !/root/i.test(name))).toBe(true);
+
+      // Expected: schemas named after the source filenames.
+      expect(schemas.AgentType).toBeDefined();
+      expect(schemas.UserType).toBeDefined();
+
+      expect(
+        schema.paths['/agents'].get.responses['200'].content['application/json'].schema.$ref,
+      ).toBe('#/components/schemas/AgentType');
+      expect(
+        schema.paths['/users'].get.responses['200'].content['application/json'].schema.$ref,
+      ).toBe('#/components/schemas/UserType');
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
   it('bundles multiple references to the same file correctly', async () => {
     const refParser = new $RefParser();
     const pathOrUrlOrSchema = path.join(

--- a/packages/json-schema-ref-parser/src/bundle.ts
+++ b/packages/json-schema-ref-parser/src/bundle.ts
@@ -618,8 +618,10 @@ function remap(parser: $RefParser, inventory: Array<InventoryEntry>) {
         // Ignore errors
       }
 
-      // Try without prefix first (cleaner names)
-      const schemaName = lastToken(entry.hash);
+      // For whole-file $refs (no hash), the filename IS the schema identity —
+      // `lastToken` would return the placeholder "root", so prefer `proposedBase`.
+      const isWholeFileRef = !entry.hash || entry.hash === '#';
+      const schemaName = isWholeFileRef ? proposedBase : lastToken(entry.hash);
       let proposed = schemaName;
 
       // Check if this name would conflict with existing schemas from other files
@@ -630,7 +632,7 @@ function remap(parser: $RefParser, inventory: Array<InventoryEntry>) {
 
       // If the name is already used, add the file prefix
       if (used.has(proposed)) {
-        proposed = `${proposedBase}_${schemaName}`;
+        proposed = isWholeFileRef ? proposedBase : `${proposedBase}_${schemaName}`;
       }
 
       defName = uniqueName(container, proposed);


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/3939

## Summary

When an OpenAPI spec uses **whole-file `$ref`s** (no URL fragment) to pull in external schemas, the bundler was naming them `root`, `<Filename>_root`, `<Filename>_root_2`, … instead of using the source filename. Downstream PascalCase turned these into `Root`, `<Filename>Root`, etc.

`lastToken(entry.hash)` returned the literal string `"root"` for empty hashes, and the bundling loop only consulted the filename-derived `proposedBase` as a *collision suffix* — so the bare name `root` always won. URL-fragment refs (`./file.yml#/components/schemas/Foo`) were unaffected.

## Example

```yaml
# root.yml
paths:
  /agents:
    get:
      responses:
        '200':
          content:
            application/json:
              schema: { $ref: './AgentType.yml' }   # whole-file ref
  /users:
    get:
      responses:
        '200':
          content:
            application/json:
              schema: { $ref: './UserType.yml' }    # whole-file ref
```

**Before:**

```jsonc
components:
  schemas:
    root:          { ... }   // AgentType
    UserType_root: { ... }   // UserType
```

**After:**

```jsonc
components:
  schemas:
    AgentType: { ... }
    UserType:  { ... }
```

## Fix

In `packages/json-schema-ref-parser/src/bundle.ts`, branch on whether the ref is whole-file and prefer `proposedBase` (the filename without extension) as the primary name. On collision, fall back to `proposedBase` and let `uniqueName` append `_2`, `_3`, …

```ts
const isWholeFileRef = !entry.hash || entry.hash === '#';
const schemaName = isWholeFileRef ? proposedBase : lastToken(entry.hash);
let proposed = schemaName;
// ...
if (used.has(proposed)) {
  proposed = isWholeFileRef ? proposedBase : `${proposedBase}_${schemaName}`;
}
```

URL-fragment refs are unaffected — `lastToken(entry.hash)` still wins when a hash is present.

## Test plan

- [x] New test: `names whole-file $refs after the source filename, not "root"` in `packages/json-schema-ref-parser/src/__tests__/bundle.test.ts` — fails on `main`, passes with the fix.
- [x] Full `@hey-api/json-schema-ref-parser` suite passes (20/20), including existing sibling-hoisting and collision tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)