### PR TITLE
fix: reassign `HttpHeaders` after delete in Angular client

### DIFF
--- a/.changeset/orange-symbols-reply.md
+++ b/.changeset/orange-symbols-reply.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+The fix reassigns the result of HttpHeaders.delete() back to opts.headers. Angular's HttpHeaders is immutable — .delete() returns a new instance rather than mutating in place — so without the assignment, the Content-Type header was never actually removed on bodyless requests.

--- a/.changeset/orange-symbols-reply.md
+++ b/.changeset/orange-symbols-reply.md
@@ -2,4 +2,4 @@
 "@hey-api/openapi-ts": patch
 ---
 
-The fix reassigns the result of HttpHeaders.delete() back to opts.headers. Angular's HttpHeaders is immutable — .delete() returns a new instance rather than mutating in place — so without the assignment, the Content-Type header was never actually removed on bodyless requests.
+**plugin(@hey-api/client-angular)**: fix: reassign the result of `HttpHeaders.delete()` back to `opts.headers`

--- a/examples/openapi-ts-angular-common/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-angular-common/src/client/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/examples/openapi-ts-angular/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-angular/src/client/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/client.gen.ts
+++ b/examples/openapi-ts-tanstack-angular-query-experimental/src/client/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/2.0.x/plugins/@angular/common/default/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.0.x/plugins/@angular/common/default/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-false/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-number/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-strict/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/base-url-string/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/clean-false/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/default/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/import-file-extension-ts/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-optional/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/sdk-client-required/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-node16-sdk/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/clients/@hey-api/client-angular/tsconfig-nodenext-sdk/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default-class/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/plugins/@angular/common/default/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/client.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/client/client.gen.ts
@@ -84,7 +84,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);

--- a/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/client.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/client-angular/bundle/client.ts
@@ -82,7 +82,7 @@ export const createClient = (config: Config = {}): Client => {
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
     if (opts.body === undefined || opts.serializedBody === '') {
-      opts.headers.delete('Content-Type');
+      opts.headers = opts.headers.delete('Content-Type');
     }
 
     const url = buildUrl(opts as Config & RequestOptions);


### PR DESCRIPTION
Angular's `HttpHeaders` is immutable, `.delete()` returns a new instance with the header removed rather than mutating in place. The result was not being reassigned to `opts.headers`, so `Content-Type` was silently never removed on bodyless requests.

Fixes #3987.

- Reassign `opts.headers = opts.headers.delete('Content-Type')` in the Angular client gen