### PR TITLE
fix(sdk): don't expose SSE errors as iterator return types

### DIFF
--- a/.changeset/fifty-lies-move.md
+++ b/.changeset/fifty-lies-move.md
@@ -1,0 +1,5 @@
+---
+"@hey-api/openapi-ts": patch
+---
+
+**sdk**: fix: don't expose SSE errors as iterator return types

--- a/.changeset/fifty-lies-move.md
+++ b/.changeset/fifty-lies-move.md
@@ -2,4 +2,4 @@
 "@hey-api/openapi-ts": patch
 ---
 
-**sdk**: fix: don't expose SSE errors as iterator return types
+**plugin(@hey-api/sdk)**: fix: don't expose SSE errors as iterator return types

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-angular/sdk.gen.ts
@@ -23,4 +23,4 @@ export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends 
  *
  * Get events
  */
-export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses, unknown | void, ThrowOnError>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });
+export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-axios/sdk.gen.ts
@@ -23,7 +23,7 @@ export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends 
  *
  * Get events
  */
-export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses, unknown | void, ThrowOnError>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({
+export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({
     responseType: 'text',
     url: '/event',
     ...options

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-fetch/sdk.gen.ts
@@ -23,4 +23,4 @@ export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends 
  *
  * Get events
  */
-export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses, unknown | void, ThrowOnError>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });
+export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-next/sdk.gen.ts
@@ -23,4 +23,4 @@ export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends 
  *
  * Get events
  */
-export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses, unknown | void, ThrowOnError>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });
+export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });

--- a/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-ofetch/sdk.gen.ts
+++ b/packages/openapi-ts-tests/main/test/__snapshots__/3.1.x/sse-ofetch/sdk.gen.ts
@@ -23,4 +23,4 @@ export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends 
  *
  * Get events
  */
-export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses, unknown | void, ThrowOnError>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });
+export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/sdk.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/export-all/sdk.gen.ts
@@ -103,7 +103,7 @@ export const globalHealth = <ThrowOnError extends boolean = false>(options?: Opt
  *
  * Subscribe to global events from the OpenCode system using server-sent events.
  */
-export const globalEvent = <ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError, GlobalEventResponse>): Promise<ServerSentEventsResult<GlobalEventResponses, GlobalEventErrors | void, ThrowOnError>> => (options?.client ?? client).sse.get<GlobalEventResponses, GlobalEventErrors, ThrowOnError>({ url: '/global/event', ...options });
+export const globalEvent = <ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError, GlobalEventResponse>): Promise<ServerSentEventsResult<GlobalEventResponses>> => (options?.client ?? client).sse.get<GlobalEventResponses, GlobalEventErrors, ThrowOnError>({ url: '/global/event', ...options });
 
 /**
  * Get global configuration
@@ -169,7 +169,7 @@ export const globalUpgrade = <ThrowOnError extends boolean = false>(parameters?:
 export const eventSubscribe = <ThrowOnError extends boolean = false>(parameters?: {
     directory?: string;
     workspace?: string;
-}, options?: Options<never, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses, unknown | void, ThrowOnError>> => {
+}, options?: Options<never, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses>> => {
     const params = buildClientParams([parameters], [{ args: [{ in: 'query', key: 'directory' }, { in: 'query', key: 'workspace' }] }]);
     return (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({
         url: '/event',

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/sdk.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/flat/sdk.gen.ts
@@ -103,7 +103,7 @@ export const globalHealth = <ThrowOnError extends boolean = false>(options?: Opt
  *
  * Subscribe to global events from the OpenCode system using server-sent events.
  */
-export const globalEvent = <ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError, GlobalEventResponse>): Promise<ServerSentEventsResult<GlobalEventResponses, GlobalEventErrors | void, ThrowOnError>> => (options?.client ?? client).sse.get<GlobalEventResponses, GlobalEventErrors, ThrowOnError>({ url: '/global/event', ...options });
+export const globalEvent = <ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError, GlobalEventResponse>): Promise<ServerSentEventsResult<GlobalEventResponses>> => (options?.client ?? client).sse.get<GlobalEventResponses, GlobalEventErrors, ThrowOnError>({ url: '/global/event', ...options });
 
 /**
  * Get global configuration
@@ -169,7 +169,7 @@ export const globalUpgrade = <ThrowOnError extends boolean = false>(parameters?:
 export const eventSubscribe = <ThrowOnError extends boolean = false>(parameters?: {
     directory?: string;
     workspace?: string;
-}, options?: Options<never, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses, unknown | void, ThrowOnError>> => {
+}, options?: Options<never, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses>> => {
     const params = buildClientParams([parameters], [{ args: [{ in: 'query', key: 'directory' }, { in: 'query', key: 'workspace' }] }]);
     return (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({
         url: '/event',

--- a/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/sdk.gen.ts
+++ b/packages/openapi-ts-tests/sdks/__snapshots__/opencode/grouped/sdk.gen.ts
@@ -65,7 +65,7 @@ export const globalHealth = <ThrowOnError extends boolean = false>(options?: Opt
  *
  * Subscribe to global events from the OpenCode system using server-sent events.
  */
-export const globalEvent = <ThrowOnError extends boolean = false>(options?: Options<GlobalEventData, ThrowOnError, GlobalEventResponse>): Promise<ServerSentEventsResult<GlobalEventResponses, GlobalEventErrors | void, ThrowOnError>> => (options?.client ?? client).sse.get<GlobalEventResponses, GlobalEventErrors, ThrowOnError>({ url: '/global/event', ...options });
+export const globalEvent = <ThrowOnError extends boolean = false>(options?: Options<GlobalEventData, ThrowOnError, GlobalEventResponse>): Promise<ServerSentEventsResult<GlobalEventResponses>> => (options?.client ?? client).sse.get<GlobalEventResponses, GlobalEventErrors, ThrowOnError>({ url: '/global/event', ...options });
 
 /**
  * Get global configuration
@@ -114,7 +114,7 @@ export const globalUpgrade = <ThrowOnError extends boolean = false>(options?: Op
  *
  * Get events
  */
-export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses, unknown | void, ThrowOnError>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });
+export const eventSubscribe = <ThrowOnError extends boolean = false>(options?: Options<EventSubscribeData, ThrowOnError, EventSubscribeResponse>): Promise<ServerSentEventsResult<EventSubscribeResponses>> => (options?.client ?? client).sse.get<EventSubscribeResponses, unknown, ThrowOnError>({ url: '/event', ...options });
 
 /**
  * Get configuration

--- a/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/sse-react-query/sdk.gen.ts
+++ b/packages/openapi-ts-tests/tanstack-query/v5/__snapshots__/3.1.x/sse-react-query/sdk.gen.ts
@@ -21,7 +21,7 @@ export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends 
 /**
  * Subscribe to event stream
  */
-export const subscribeToEventStream = <ThrowOnError extends boolean = false>(options?: Options<SubscribeToEventStreamData, ThrowOnError, SubscribeToEventStreamResponse>): Promise<ServerSentEventsResult<SubscribeToEventStreamResponses, unknown | void, ThrowOnError>> => (options?.client ?? client).sse.post<SubscribeToEventStreamResponses, unknown, ThrowOnError>({ url: '/events/subscribe', ...options });
+export const subscribeToEventStream = <ThrowOnError extends boolean = false>(options?: Options<SubscribeToEventStreamData, ThrowOnError, SubscribeToEventStreamResponse>): Promise<ServerSentEventsResult<SubscribeToEventStreamResponses>> => (options?.client ?? client).sse.post<SubscribeToEventStreamResponses, unknown, ThrowOnError>({ url: '/events/subscribe', ...options });
 
 /**
  * List events

--- a/packages/openapi-ts/src/plugins/@hey-api/sdk/shared/operation.ts
+++ b/packages/openapi-ts/src/plugins/@hey-api/sdk/shared/operation.ts
@@ -516,12 +516,7 @@ export function operationReturnType({
   }
 
   if (isSse) {
-    return $.type('Promise').generic(
-      sseResult
-        .generic(queryType('responses'))
-        .generic($.type.or(queryType('errors'), $.type('void')))
-        .generic('ThrowOnError'),
-    );
+    return $.type('Promise').generic(sseResult.generic(queryType('responses')));
   }
 
   return requestResult


### PR DESCRIPTION
Closes https://github.com/hey-api/openapi-ts/issues/3990

## Summary

Follow-up to #3919.

#3919 correctly fixed generated client `SseFn` types so endpoint HTTP errors are no longer threaded into `ServerSentEventsResult`'s second generic slot. That slot is `AsyncGenerator`'s `TReturn`, not an error channel.

However, the SDK return type builder still emits the old SSE shape:

```ts
Promise<ServerSentEventsResult<Responses, Errors | void, ThrowOnError>>
```

while generated clients now return:

```ts
Promise<ServerSentEventsResult<Responses>>
```

This makes generated SDK functions fail TypeScript assignability checks for SSE endpoints with concrete error responses.

## Change

For SSE operations, the SDK return annotation now mirrors the client result shape:

```ts
Promise<ServerSentEventsResult<Responses>>
```

The generated call expression still passes `<Responses, Errors, ThrowOnError>` into `client.sse.*` to preserve compatibility with the current `SseFn` generic arity introduced/preserved by #3919.

Updated generated snapshots covering:

- the main 3.1.x SSE client fixtures for Angular, Axios, Fetch, Next.js, and ofetch
- the TanStack Query SSE fixture
- the SDK opencode fixtures for flat, grouped, and export-all outputs

Nuxt is unchanged because its SSE type shape is different: it wraps `RequestResult` inside `ServerSentEventsResult` rather than passing the HTTP error type as `TReturn`.

## Why

HTTP errors are not the async iterator completion value. They are handled by the initial request promise / SSE error hooks. The public SDK return type should therefore not expose endpoint error types through `ServerSentEventsResult`'s `TReturn`.

## Test plan

- `pnpm vitest run` across `@test/openapi-ts-sdks`, `@test/openapi-ts`, `@test/openapi-ts-tanstack-query-v5`
- `pnpm typecheck`
- `pnpm lint:fix`
